### PR TITLE
docs: phase 1 planning updates and agent config

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -9,10 +9,10 @@ Requirements for initial milestone. Each maps to roadmap phases.
 
 ### SmartTransaction Removal
 
-- [ ] **SMTX-01**: All manager methods (`DaoManager`, `OrderManager`, `LogicManager`, `OwnedOwnerManager`, `CapacityManager`, `UdtManager`, `IckbUdtManager`) accept `ccc.Transaction` instead of `SmartTransaction`
+- [ ] **SMTX-01**: All manager method signatures across all 5 library packages accept `ccc.TransactionLike` instead of `SmartTransaction`, following CCC's convention (TransactionLike input, Transaction output); `CapacityManager` is deleted (not migrated)
 - [ ] **SMTX-02**: `SmartTransaction` class and its `completeFee()` override are deleted from `@ickb/utils`
 - [ ] **SMTX-03**: Fee completion uses CCC-native `ccc.Transaction.completeFeeBy()` or `completeFeeChangeToLock()` with DAO-aware capacity calculation
-- [ ] **SMTX-04**: Header caching delegates to `ccc.Client.cache` instead of `SmartTransaction.headers` map
+- [ ] **SMTX-04**: `getHeader()` function and `HeaderKey` type are removed from `@ickb/utils`; all call sites inline CCC client calls (`client.getTransactionWithHeader()`, `client.getHeaderByNumber()`); header caching handled transparently by `ccc.Client.cache`
 - [ ] **SMTX-05**: UDT handler registration (`addUdtHandlers()`) is replaced by direct `Udt` instance usage or standalone utility functions
 - [ ] **SMTX-06**: 64-output NervosDAO limit check is consolidated into a single utility function (currently scattered across 6 locations)
 - [ ] **SMTX-07**: `IckbUdtManager` multi-representation UDT balance logic (xUDT + receipts + deposits) survives removal intact -- conservation law `Input UDT + Input Receipts = Output UDT + Input Deposits` is preserved
@@ -31,7 +31,7 @@ Requirements for initial milestone. Each maps to roadmap phases.
 ### CCC Udt Integration
 
 - [ ] **UDT-01**: Feasibility assessment completed: can `IckbUdt extends udt.Udt` override `infoFrom()` or `getInputsInfo()`/`getOutputsInfo()` to account for receipt cells and deposit cells alongside xUDT cells
-- [ ] **UDT-02**: Header access pattern for receipt value calculation is designed -- determine whether `client.getCellWithHeader()`, `client.getHeaderByTxHash()`, or the existing `getHeader()` pattern is used within the Udt override
+- [ ] **UDT-02**: Header access pattern for receipt value calculation is designed -- determine whether `client.getCellWithHeader()`, `client.getHeaderByTxHash()`, or direct CCC client calls are used within the Udt override (`getHeader()` utility removed in Phase 1)
 - [ ] **UDT-03**: Decision documented: subclass CCC `Udt` vs. keep custom `UdtHandler` interface vs. hybrid approach
 - [ ] **UDT-04**: If subclassing is viable, `IckbUdt` class is implemented in `@ickb/core` with multi-representation balance calculation
 - [ ] **UDT-05**: If subclassing is not viable, `IckbUdtManager` is refactored to work with plain `ccc.Transaction` (no SmartTransaction dependency) while maintaining a compatible interface
@@ -79,28 +79,28 @@ Explicitly excluded. Documented to prevent scope creep.
 
 Which phases cover which requirements. Updated during roadmap creation.
 
-| Requirement | Phase | Status |
-|-------------|-------|--------|
-| SMTX-01 | Phase 5 | Pending |
-| SMTX-02 | Phase 1 | Pending |
-| SMTX-03 | Phase 6 | Pending |
-| SMTX-04 | Phase 1 | Pending |
-| SMTX-05 | Phase 4 | Pending |
-| SMTX-06 | Phase 1 | Pending |
-| SMTX-07 | Phase 5 | Pending |
-| SMTX-08 | Phase 6 | Pending |
-| SMTX-09 | Phase 7 | Pending |
-| SMTX-10 | Phase 4 | Pending |
-| DEDUP-01 | Phase 2 | Pending |
-| DEDUP-02 | Phase 2 | Pending |
-| DEDUP-03 | Phase 2 | Pending |
-| DEDUP-04 | Phase 2 | Pending |
-| DEDUP-05 | Phase 2 | Pending |
-| UDT-01 | Phase 3 | Pending |
-| UDT-02 | Phase 3 | Pending |
-| UDT-03 | Phase 3 | Pending |
-| UDT-04 | Phase 5 | Pending |
-| UDT-05 | Phase 5 | Pending |
+| Requirement | Phase | Status | Notes |
+|-------------|-------|--------|-------|
+| SMTX-01 | Phase 1 | Pending | Feature-slice: all signatures migrated to TransactionLike across all packages |
+| SMTX-02 | Phase 1 | Pending | |
+| SMTX-03 | Phase 6 | Pending | |
+| SMTX-04 | Phase 1 | Pending | getHeader()/HeaderKey removed, CCC client calls inlined |
+| SMTX-05 | Phase 4, 5 | Pending | addUdtHandlers() removed in Phase 1; replacement pattern finalized in Phase 4-5 after Phase 3 decision |
+| SMTX-06 | Phase 1 | Pending | DAO check contributed to CCC core via ccc-dev/ |
+| SMTX-07 | Phase 5 | Pending | |
+| SMTX-08 | Phase 6 | Pending | |
+| SMTX-09 | Phase 7 | Pending | |
+| SMTX-10 | Phase 4, 5 | Pending | Deprecated calls in dao/order (Phase 4) and core (Phase 5) |
+| DEDUP-01 | Phase 2 | Pending | |
+| DEDUP-02 | Phase 2 | Pending | |
+| DEDUP-03 | Phase 2 | Pending | |
+| DEDUP-04 | Phase 2 | Pending | |
+| DEDUP-05 | Phase 2 | Pending | |
+| UDT-01 | Phase 3 | Pending | |
+| UDT-02 | Phase 3 | Pending | |
+| UDT-03 | Phase 3 | Pending | |
+| UDT-04 | Phase 5 | Pending | |
+| UDT-05 | Phase 5 | Pending | |
 
 **Coverage:**
 - v1 requirements: 20 total
@@ -109,4 +109,4 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 ---
 *Requirements defined: 2026-02-21*
-*Last updated: 2026-02-21 after roadmap creation*
+*Last updated: 2026-02-22 after Phase 1 context (feature-slice restructure)*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,14 +5,14 @@
 See: .planning/PROJECT.md (updated 2026-02-20)
 
 **Core value:** Clean, CCC-aligned library packages published to npm that frontends can depend on to interact with iCKB contracts -- no Lumos, no abandoned abstractions, no duplicated functionality with CCC.
-**Current focus:** Phase 1: @ickb/utils SmartTransaction Removal
+**Current focus:** Phase 1: SmartTransaction Removal (feature-slice)
 
 ## Current Position
 
-Phase: 1 of 7 (@ickb/utils SmartTransaction Removal)
+Phase: 1 of 7 (SmartTransaction Removal — feature-slice)
 Plan: 0 of 3 in current phase
-Status: Ready to plan
-Last activity: 2026-02-21 -- Roadmap created
+Status: Context gathered, ready to plan
+Last activity: 2026-02-22 -- Phase 1 context gathered
 
 Progress: [░░░░░░░░░░] 0%
 
@@ -42,9 +42,12 @@ Progress: [░░░░░░░░░░] 0%
 Decisions are logged in PROJECT.md Key Decisions table.
 Recent decisions affecting current work:
 
-- [Roadmap]: Bottom-up refactor order follows package dependency graph: utils -> dao+order -> core -> sdk
-- [Roadmap]: UDT investigation (Phase 3) is a design phase that produces a decision document before core implementation (Phase 5)
-- [Roadmap]: SMTX-01 (all managers accept ccc.Transaction) is verified at Phase 5 completion, after utils managers removed (Phase 1), dao+order managers updated (Phase 4), and core managers updated (Phase 5)
+- [Roadmap]: Phase 1 uses feature-slice approach — each removal chased across all packages, build stays green after every step. SMTX-01 (all signatures to TransactionLike) completed in Phase 1, not Phase 5.
+- [Roadmap]: UDT investigation (Phase 3) is a design phase that produces a decision document; its outcome determines UdtHandler/UdtManager replacement pattern used in Phases 4-5
+- [Roadmap]: Phases 4-5 reduced in scope: Phase 4 focuses on deprecated API replacement + UDT pattern finalization in dao/order; Phase 5 focuses on IckbUdt implementation + conservation law in core
+- [Phase 1 Context]: DAO 64-output limit check contributed to CCC core via ccc-dev/, CCC PR submitted during Phase 1
+- [Phase 1 Context]: getHeader()/HeaderKey removed entirely — inline CCC client calls at read-only call sites; addHeaders() call sites in DaoManager/LogicManager push to tx.headerDeps directly
+- [Phase 1 Context]: Script comparison must always use full Script.eq(), never just codeHash comparison
 
 ### Pending Todos
 
@@ -57,6 +60,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-02-21
-Stopped at: Roadmap created, ready for Phase 1 planning
-Resume file: None
+Last session: 2026-02-22
+Stopped at: Phase 1 context gathered
+Resume file: .planning/phases/01-ickb-utils-smarttransaction-removal/01-CONTEXT.md

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -31,13 +31,13 @@ The iCKB protocol solves NervosDAO illiquidity by pooling DAO deposits and issui
 
 **Exchange Rate:** `iCKB_value = unoccupied_capacity * AR_0 / AR_m` where `AR_0 = 10^16` (genesis accumulated rate) and `AR_m` is the accumulated rate at the deposit block. CKB is inflationary; iCKB is not -- 1 iCKB represents an ever-increasing amount of CKB over time.
 
-**Deposit (2-Phase):**
-1. Phase 1: User deposits CKB into NervosDAO -> receives a Receipt cell (cannot calculate iCKB value yet because the block's accumulated rate isn't available during validation).
-2. Phase 2: Receipt cell is converted to iCKB xUDT tokens using the now-available accumulated rate from the deposit block header.
+**Deposit (2-Step):**
+1. Step 1: User deposits CKB into NervosDAO -> receives a Receipt cell (cannot calculate iCKB value yet because the block's accumulated rate isn't available during validation).
+2. Step 2: Receipt cell is converted to iCKB xUDT tokens using the now-available accumulated rate from the deposit block header.
 
-**Withdrawal (2-Phase):**
-1. Phase 1: User burns iCKB tokens -> creates a NervosDAO withdrawal request (using any mature deposit from the pool, not necessarily the user's original deposit).
-2. Phase 2: Standard NervosDAO withdrawal after 180-epoch maturity.
+**Withdrawal (2-Step):**
+1. Step 1: User burns iCKB tokens -> creates a NervosDAO withdrawal request (using any mature deposit from the pool, not necessarily the user's original deposit).
+2. Step 2: Standard NervosDAO withdrawal after 180-epoch maturity.
 
 **Soft Cap Penalty:** Deposits exceeding 100,000 iCKB-equivalent incur a 10% discount on the excess amount. This incentivizes standard-size deposits (~100k CKB) and prevents DoS via fragmentation. Formula: `final = amount - (amount - 100000) / 10` when `amount > 100000`.
 

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -73,6 +73,13 @@
 packages:
   - packages/*
   - apps/*
+  - ccc-dev/ccc/packages/*
+  - "!ccc-dev/ccc/packages/demo"
+  - "!ccc-dev/ccc/packages/docs"
+  - "!ccc-dev/ccc/packages/examples"
+  - "!ccc-dev/ccc/packages/faucet"
+  - "!ccc-dev/ccc/packages/playground"
+  - "!ccc-dev/ccc/packages/tests"
 
 catalog:
   '@ckb-ccc/core': ^1.12.2
@@ -109,7 +116,7 @@ The repo supports using a local development build of CCC for testing unpublished
 
 **`.pnpmfile.cjs`:**
 - A pnpm `readPackage` hook that auto-discovers all packages in `ccc-dev/ccc/packages/*/package.json`
-- When `ccc-dev/ccc/` exists, overrides all `@ckb-ccc/*` dependency versions in the workspace with `link:` references to the local build
+- When `ccc-dev/ccc/` exists, overrides all `@ckb-ccc/*` dependency versions in the workspace with `workspace:*` (CCC packages are listed in `pnpm-workspace.yaml`, but catalog specifiers resolve to semver ranges before workspace linking, so the hook forces `workspace:*` to ensure local packages are used)
 - Applies to `dependencies`, `devDependencies`, and `optionalDependencies`
 - Effect: all workspace packages transparently use the local CCC build instead of npm versions
 

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -74,9 +74,12 @@
 │   │   ├── REFS                    # Pinned branch HEADs
 │   │   └── resolutions/            # Merge conflict resolutions
 │   ├── ccc/                        # Gitignored: ephemeral CCC clone (auto-generated)
+│   ├── patch.sh                    # Rewrites CCC exports to .ts source, creates deterministic commit
+│   ├── push.sh                     # Pushes local CCC changes upstream
 │   ├── record.sh                   # Records new pins with AI Coworker conflict resolution
 │   ├── replay.sh                   # Deterministically rebuilds ccc/ from pins
-│   └── tsc.mjs                     # TypeScript compilation script override
+│   ├── status.sh                   # Checks if ccc-dev/ccc/ has pending custom work
+│   └── tsgo-filter.sh              # Wrapper around tsgo filtering CCC diagnostics
 ├── reference/                      # Read-only reference repos (git-ignored, clone via `pnpm reference`)
 │   ├── contracts/                 # Rust on-chain contracts
 │   │   └── scripts/contracts/
@@ -309,7 +312,7 @@
     // ... methods
   }
   ```
-- Transaction methods: Accept `SmartTransaction`, call `.addCellDeps()`, `.addInput()`, `.addOutput()`
+- Transaction methods: Accept `ccc.TransactionLike`, return `ccc.Transaction`, call `.addCellDeps()`, `.addInput()`, `.addOutput()`
 - Finding methods: Use async generators for lazy cell discovery
 - Type checkers: Implement `isFoo(cell)` methods for type verification
 

--- a/.planning/phases/01-ickb-utils-smarttransaction-removal/01-CONTEXT.md
+++ b/.planning/phases/01-ickb-utils-smarttransaction-removal/01-CONTEXT.md
@@ -1,0 +1,100 @@
+# Phase 1: SmartTransaction Removal (feature-slice) - Context
+
+**Gathered:** 2026-02-22
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Delete SmartTransaction class and its infrastructure across all packages; contribute 64-output DAO limit check to CCC core; remove getHeader()/HeaderKey and inline CCC client calls; migrate all method signatures to ccc.TransactionLike. Using a **feature-slice approach**: each removal is chased across ALL packages so the build stays green at every step.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### CCC DAO Contribution (via ccc-dev/)
+- Build the 64-output NervosDAO limit check **in CCC core**, not in @ickb/utils
+- Develop in `ccc-dev/ccc/`, record pins, use immediately via workspace override while waiting for upstream merge
+- **Submit the upstream CCC PR during Phase 1 execution**
+- CCC PR includes three components:
+  1. **`completeFee()` safety net** — async check using `client.getKnownScript(KnownScript.NervosDao)` with full `Script.eq()` comparison
+  2. **Standalone utility function** — `assertDaoOutputLimit(tx, client)` that auto-resolves unresolved inputs (populating `CellInput.cellOutput` as a side effect) and checks both inputs and outputs
+  3. **`ErrorNervosDaoOutputLimit` error class** in `transactionErrors.ts` with metadata fields (count) and hardcoded limit of 64
+- The check logic: if `outputs.length > 64` AND any input or output has DAO type script, throw error
+- **PR description should mention** the possibility of adding the check to `addOutput()` as a future enhancement, inviting maintainer feedback
+- All 6+ scattered DAO checks across dao/core/utils packages are replaced with calls to the new CCC utility **in Phase 1**
+
+### getHeader() Removal
+- **Remove `getHeader()` function and `HeaderKey` type entirely** from @ickb/utils
+- Inline CCC client calls at each of the 8+ call sites across dao/core/sdk:
+  - `txHash` lookups → `(await client.getTransactionWithHeader(hash))?.header` with null check/throw
+  - `number` lookups → `await client.getHeaderByNumber(n)` with null check/throw
+- SmartTransaction's redundant `Map<hexString, Header>` cache is deleted — CCC's built-in `ClientCacheMemory` LRU (128 blocks) handles caching
+- **`addHeaders()` replacement needed** — `SmartTransaction.addHeaders()` is used by DaoManager (`requestWithdrawal`, `withdraw`) and LogicManager (`completeDeposit`) to push header hashes into `tx.headerDeps` with dedup. With SmartTransaction gone, these 3 call sites need to push to `tx.headerDeps` directly. Note: `SmartTransaction.getHeader()` (instance method) only validated that headers were already in headerDeps — it did not populate them. The standalone `getHeader()` function (being removed) never touched headerDeps at all.
+- ROADMAP success criteria updated to reflect this — no standalone `getHeader()` utility will exist
+
+### Feature-Slice Build Strategy
+- **Build must pass after every removal step** — no intermediate broken states
+- Execution order:
+  1. CCC DAO utility (adds new code, nothing breaks)
+  2. Replace all scattered DAO checks with CCC utility calls (all packages)
+  3. Remove `getHeader()`/`HeaderKey` and inline CCC calls at all call sites (all packages)
+  4. Remove SmartTransaction class and update all method signatures to `ccc.TransactionLike` (all packages)
+  5. Remove CapacityManager and update SDK call sites (utils + sdk)
+- Each step touches multiple packages but leaves `pnpm check:full` passing
+- **Roadmap updated**: Phases 4-5 reduced in scope since method signatures are already updated to `ccc.TransactionLike` in Phase 1
+
+### Method Signatures (CCC Pattern)
+- Follow CCC's convention: public APIs accept `ccc.TransactionLike` (flexible input), return `ccc.Transaction` (concrete)
+- Convert internally with `ccc.Transaction.from(txLike)` at method entry point
+- Consistent with how CCC's own udt/spore/type-id packages work
+
+### UdtHandler/UdtManager — Deferred
+- UdtHandler interface and UdtManager class **stay in @ickb/utils** for Phase 1
+- Their method signatures are updated from `SmartTransaction` to `ccc.TransactionLike` to keep the build green
+- Full replacement deferred to Phase 3+ (depends on CCC Udt integration investigation)
+- `addUdtHandlers()` call sites — Claude's discretion on replacement approach
+
+### CapacityManager — Fully Removed
+- CapacityManager is deleted from @ickb/utils
+- Only consumer is `@ickb/sdk` (`findCapacities()` in sdk.ts, constructor in constants.ts)
+- SDK call sites updated to use CCC's native cell finding
+
+### Removal Approach
+- **Clean delete** — no deprecation stubs, no migration comments, no breadcrumbs
+- File deletions + barrel export removal in the **same commit** (atomic)
+- Files deleted: `transaction.ts`, `capacity.ts` (from @ickb/utils)
+- Files kept: `udt.ts` (signatures updated), `utils.ts` (getHeader/HeaderKey removed), `codec.ts`, `heap.ts`, `index.ts`
+- `utils.ts` keeps its name — no rename needed
+
+### Claude's Discretion
+- `addUdtHandlers()` replacement strategy at call sites
+- CapacityManager replacement approach in SDK (CCC native equivalent)
+- Exact commit boundaries within each feature-slice step
+- CCC PR code style and test approach (follow CCC's vitest patterns)
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- **Script comparison must use `eq()`** — never compare just `codeHash`. Always compare the full Script (codeHash + hashType + args) using CCC's `Script.eq()` method. This applies across the entire codebase, not just the DAO check. Downstream agents must follow this pattern for all script identification.
+- NervosDao type script is invariant across mainnet, testnet, devnet — the code hash is a genesis constant. The CCC PR can reference this fact.
+- CCC's existing `Cell.isNervosDao(client)` is async and uses client resolution — the new utility should be consistent with this pattern.
+- The CCC PR should follow CCC's error class conventions: see `ErrorTransactionInsufficientCapacity` and `ErrorTransactionInsufficientCoin` in `transactionErrors.ts` for the pattern.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **addOutput() DAO check** — Sync check in `Transaction.addOutput()` using hardcoded DAO script when outputs > 64. Deferred due to CCC maintainer acceptance concerns (hot path overhead, even though it only triggers past 64 outputs). Mentioned in CCC PR description as future possibility.
+- **getHeader as CCC contribution** — A unified header lookup function (`client.getHeader(key)`) could be contributed to CCC itself, making iCKB's wrapper unnecessary. Low priority since the wrapper is being removed and calls inlined.
+
+</deferred>
+
+---
+
+*Phase: 01-ickb-utils-smarttransaction-removal*
+*Context gathered: 2026-02-22*

--- a/.planning/research/FEATURES.md
+++ b/.planning/research/FEATURES.md
@@ -87,8 +87,8 @@ SmartTransaction Removal (TS-1)
 
 CCC Udt Investigation (D-2)
     |
-    +-- requires --> SmartTransaction Removal (TS-1)
-    |                   (must understand new API shape first)
+    +-- can parallel --> SmartTransaction Removal (TS-1)
+    |                   (design investigation, no code changes -- can proceed in parallel)
     |
     +-- informs --> Multi-representation UDT (D-1)
                         (whether to use Udt interface or custom)
@@ -122,7 +122,7 @@ npm Publication (TS-11)
 - **TS-1 (SmartTransaction Removal) is the critical path.** Every downstream task depends on it. It must happen first and must preserve D-1 (multi-representation UDT) and D-3 (conversion preview) functionality.
 - **TS-5 (Bot Migration) validates the entire stack.** The bot exercises deposits, withdrawals, order matching, fee completion, and UDT balancing under real conditions. It is the integration test for the library suite.
 - **TS-4 (Lumos Removal) is the final gate.** It can only happen after all three legacy apps are migrated. It removes `@ickb/lumos-utils`, `@ickb/v1-core`, and all `@ckb-lumos/*` from the monorepo.
-- **D-2 (CCC Udt Investigation) is exploratory.** It should not block other work. Findings inform the API design of D-1 but the library can ship with a custom `UdtHandler` interface regardless.
+- **D-2 (CCC Udt Investigation) is exploratory.** It can proceed in parallel with SmartTransaction removal (design investigation, not code changes). Findings inform the API design of D-1 but the library can ship with a custom `UdtHandler` interface regardless.
 - **CCC PR #328 (FeePayer) is external.** Track it but do not depend on it. Design the SmartTransaction replacement so that FeePayer can be adopted later if it merges.
 
 ## MVP Definition
@@ -131,7 +131,7 @@ npm Publication (TS-11)
 
 Minimum viable state for npm publication of clean CCC-aligned library packages.
 
-- [ ] **TS-1: SmartTransaction removal** -- Replace with utility functions on `ccc.Transaction`. This is the single most important task. All manager methods must accept `ccc.Transaction` instead of `SmartTransaction`.
+- [ ] **TS-1: SmartTransaction removal** -- Replace with utility functions on `ccc.Transaction`. This is the single most important task. All manager methods must accept `ccc.TransactionLike` instead of `SmartTransaction` (CCC convention: TransactionLike input, Transaction output).
 - [ ] **TS-2: CCC utility deduplication** -- Adopt CCC equivalents for `max`/`min`/`gcd`/`isHex`/`hexFrom`.
 - [ ] **TS-3: Clean public API** -- Audit exports, ensure intentional public surface, proper type exports.
 - [ ] **TS-5: Bot migration** -- Validates the library packages work end-to-end under production conditions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,27 @@
 # AI Coworker Configuration
 
-This file is the tool-agnostic agent config:
+## Meta
 
 - **Learn**: When a non-obvious constraint causes a failure, leave a concise note here and a detailed comment at the relevant location
+- `CLAUDE.md` is a symlink to this file, created by `pnpm coworker`
 - Refer to yourself as "AI Coworker" in docs and comments, not by product or company name
 - Never add AI tool attribution or branding to PR descriptions, commit messages, or code comments
 - Do not install or use `gh` CLI
+
+## Workflows
+
 - **Routine Pre-PR Validation**: `pnpm check:full`, it wipes derived state and regenerates from scratch. If `ccc-dev/ccc/` has pending work, the wipe is skipped to prevent data loss — re-record or push CCC changes first for a clean validation
-- **Open a PR**: Push the branch, then construct and present a GitHub compare URL
-  (`quick_pull=1`) to the user. Base branch is `master`. Prefill "title" (concise, under 70 chars) and "body" (markdown with ## Why and ## Changes sections)
+- **Open a PR**: Push the branch, then present a clickable markdown link `[title](url)` where the URL is a GitHub compare URL (`quick_pull=1`). Base branch is `master`. Prefill "title" (concise, under 70 chars) and "body" (markdown with ## Why and ## Changes sections)
 - **Fetch PR review comments**: Use the GitHub REST API via curl. Fetch all three comment types (issue comments, reviews, and inline comments). Reviewers reply asynchronously — poll every minute until comments arrive
 - **Copy to clipboard**:
-  ```
+
+  ```sh
   head -c -1 <<'EOF' | wl-copy
   content goes here
   EOF
   ```
 
-# CCC Local Development (ccc-dev/)
+## CCC Local Development (ccc-dev/)
 
 The `ccc-dev/` system uses a record/replay mechanism for deterministic builds of a local CCC fork:
 
@@ -29,10 +33,14 @@ The `ccc-dev/` system uses a record/replay mechanism for deterministic builds of
 - `ccc-dev/patch.sh` rewrites CCC package exports to point at `.ts` source instead of `.d.ts`, then creates a deterministic git commit (fixed author/date) so record and replay produce the same `pins/HEAD` hash. This is why imports from `@ckb-ccc/*` resolve to TypeScript source files inside `node_modules` — it is not a bug
 - `ccc-dev/tsgo-filter.sh` is a bash wrapper around `tsgo` that filters out diagnostics originating from `ccc-dev/ccc/`. CCC source does not satisfy this repo's strict tsconfig (`verbatimModuleSyntax`, `noUncheckedIndexedAccess`, `noImplicitOverride`), so the wrapper suppresses those errors while still reporting errors in stack source
 
-# Reference Repos
+## Reference Repos
 
 `reference/` contains read-only clones (project knowledge, dependency sources, etc.) fetched via `pnpm reference`. To refresh, delete the directory and re-run `pnpm reference`
 
-# Versioning
+## Versioning
 
 All packages use version `1001.0.0` (Epoch Semantic Versioning), managed by changesets (`pnpm changeset`)
+
+## Knowledge
+
+- Always compare CKB scripts using full `Script.eq()` (codeHash + hashType + args), never just `codeHash`. Partial comparison silently matches wrong scripts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
     devDependencies:
       '@anthropic-ai/claude-code':
         specifier: latest
-        version: 2.1.49
+        version: 2.1.50
       '@changesets/changelog-github':
         specifier: ^0.5.2
         version: 0.5.2
@@ -30,7 +30,7 @@ importers:
         version: 9.39.3
       '@typescript/native-preview':
         specifier: latest
-        version: 7.0.0-dev.20260220.1
+        version: 7.0.0-dev.20260221.1
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
@@ -539,7 +539,7 @@ importers:
         version: 4.3.0(prettier@3.8.1)(typescript@5.9.3)
       tsdown:
         specifier: 0.19.0-beta.3
-        version: 0.19.0-beta.3(@typescript/native-preview@7.0.0-dev.20260220.1)(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.19.0-beta.3(@typescript/native-preview@7.0.0-dev.20260221.1)(synckit@0.11.12)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -972,7 +972,7 @@ importers:
         version: 4.3.0(prettier@3.8.1)(typescript@5.9.3)
       tsdown:
         specifier: 0.19.0-beta.3
-        version: 0.19.0-beta.3(@typescript/native-preview@7.0.0-dev.20260220.1)(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.19.0-beta.3(@typescript/native-preview@7.0.0-dev.20260221.1)(synckit@0.11.12)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -1203,8 +1203,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@2.1.49':
-    resolution: {integrity: sha512-PonEmTZlB5IZbBu9TmtOpGZnupU7OxOXTsJKcXE/4Ak5qp3ptN1wSBRdgKYnn6GDYhXijTXuVVwrCQU+NAgwPA==}
+  '@anthropic-ai/claude-code@2.1.50':
+    resolution: {integrity: sha512-urrhY4IRuLHFoEYb6pjRy6sbDE8TH886zwRvIAPS4Tz51MeGVomZet4EajqxX6+IOKbJNbf4IHL3fTzI0vcKXA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2810,43 +2810,43 @@ packages:
     resolution: {integrity: sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260220.1':
-    resolution: {integrity: sha512-VZQHVaLYTpa3wfCLcFD5cfnegr4iDtzBxV6yh3tys+HYePi4TXuAqct/dmziW0cpCo/UQ2KqAPGxwVO3YMDYJA==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260221.1':
+    resolution: {integrity: sha512-m3ttEpK+eXV7P06RVZZuSuUvNDj8psXODrMJRRQWpTNsk3qITbIdBSgOx2Q/M3tbQ9Mo2IBHt6jUjqOdRW9oZQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260220.1':
-    resolution: {integrity: sha512-ieGtyz904rlme8YWauDpCqGbnOQQ5dzUyRKU25I7MNIaoZFf0vK5gMh3SLjHC7ayWxjrCa2ezH4ka8UmyWQcPg==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260221.1':
+    resolution: {integrity: sha512-BNaNe3rox2rpkh5sWcnZZob6sDA/at9KK55/WSRAH4W+9dFReOLFAR9YXhKxrLGZ1QpleuIBahKbV8o037S+pA==}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260220.1':
-    resolution: {integrity: sha512-nlOOABSQUe6ix/KOsZS3ALZ/sg9rhtp6SKtQnXO8X4+2XUlwVYS6nIrAQ5jG4+OsCvcESttNeHhBw817uNrsuA==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260221.1':
+    resolution: {integrity: sha512-Y4jsvwDq86LXq63UYRLqCAd+nD1r6C2NVaGNR39H+c6D8SgOBkPLJa8quTH0Ir8E5bsR8vTN4E6xHY9jD4J2PA==}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260220.1':
-    resolution: {integrity: sha512-wMA63N6XLAkO0Ibq1Qz2zkQHF6oLynYh5+q1YayzWxp1FOas0oJUdNgVbiWeisAT4IEI9SmYtVwJJNTm/cwrwg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260221.1':
+    resolution: {integrity: sha512-+/uyIw7vg4FyAnNpsCJHmSOhMiR2m56lqaEo1J5pMAstJmfLTTKQdJ1muIWCDCqc24k2U30IStHOaCqUerp/nQ==}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260220.1':
-    resolution: {integrity: sha512-W7R/5ct/BGuPAmJuKFU0ZuLU2nzLA26XfoaoUHHoTLYRMMuY3LBv+7zKSUTlSGjayeWQ5KtDrfrY72LarWAXkQ==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260221.1':
+    resolution: {integrity: sha512-7agd5FtVLPp+gRMvsecSDmdQ/XM80q/uaQ6+Kahan9uNrCuPJIyMiAtJvCoYYgT1nXX2AjwZk39DH63fRaw/Mg==}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260220.1':
-    resolution: {integrity: sha512-FNXTr2lS1QLUB05jWjkBVwrDierNuxKduQq9ayloENJrsC8GfG1sXkfy8R021+ozP/D1LI/CFUn3hkB2vPXTsQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260221.1':
+    resolution: {integrity: sha512-lXbsy5vDzS//oE0evX+QwZBwpKselXTd8H18lT42CBQo2hL2r0+w9YBguaYXrnGkAoHjDXEfKA2xii8yVZKVUg==}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260220.1':
-    resolution: {integrity: sha512-byHRyf4dOuKOADrs43tWyPhmAgqk+XrA/XOsJnGsxUKxPwots+gf9x5kg/IxTbB3QjPsVe/V9QdMl3//sUTCmQ==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260221.1':
+    resolution: {integrity: sha512-O02pfQlVlRTsBmp0hODs/bOHm2ic2kXZpIchBP5Qm0wKCp1Ytz/7i3SNT1gN47I+KC4axn/AHhFmkWQyIu9kRQ==}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260220.1':
-    resolution: {integrity: sha512-trYXlG98/C7Q7pqnPrKo+ksXrWqWVMncCy2x0VftD2llfL99Z//g2mpB9TmzWeKgb4d1659ESvxTowCGnzMccw==}
+  '@typescript/native-preview@7.0.0-dev.20260221.1':
+    resolution: {integrity: sha512-tEUzcnj6pD+z1vANchRzhpPl+3RMD+xQRvIN//0+qjtP5zyYB5T+MIaAWycpKDwlHP9C13JnQgcgYnC+LlNkrg==}
     hasBin: true
 
   '@vitejs/plugin-basic-ssl@1.2.0':
@@ -4749,7 +4749,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-code@2.1.49':
+  '@anthropic-ai/claude-code@2.1.50':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -6361,36 +6361,36 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       eslint-visitor-keys: 5.0.0
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260220.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260221.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260220.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260221.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260220.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260221.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260220.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260221.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260220.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260221.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260220.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260221.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260220.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260221.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260220.1':
+  '@typescript/native-preview@7.0.0-dev.20260221.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260220.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260220.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260220.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260220.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260220.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260220.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260220.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260221.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260221.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260221.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260221.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260221.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260221.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260221.1
 
   '@vitejs/plugin-basic-ssl@1.2.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
@@ -7703,7 +7703,7 @@ snapshots:
       glob: 13.0.5
       package-json-from-dist: 1.0.1
 
-  rolldown-plugin-dts@0.20.0(@typescript/native-preview@7.0.0-dev.20260220.1)(rolldown@1.0.0-beta.58)(typescript@5.9.3):
+  rolldown-plugin-dts@0.20.0(@typescript/native-preview@7.0.0-dev.20260221.1)(rolldown@1.0.0-beta.58)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.0
@@ -7715,7 +7715,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-beta.58
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260220.1
+      '@typescript/native-preview': 7.0.0-dev.20260221.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -7953,7 +7953,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tsdown@0.19.0-beta.3(@typescript/native-preview@7.0.0-dev.20260220.1)(synckit@0.11.12)(typescript@5.9.3):
+  tsdown@0.19.0-beta.3(@typescript/native-preview@7.0.0-dev.20260221.1)(synckit@0.11.12)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -7964,7 +7964,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.3
       rolldown: 1.0.0-beta.58
-      rolldown-plugin-dts: 0.20.0(@typescript/native-preview@7.0.0-dev.20260220.1)(rolldown@1.0.0-beta.58)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.20.0(@typescript/native-preview@7.0.0-dev.20260221.1)(rolldown@1.0.0-beta.58)(typescript@5.9.3)
       semver: 7.7.4
       tinyexec: 1.0.2
       tinyglobby: 0.2.15


### PR DESCRIPTION
## Why

Capture phase 1 context decisions and reconcile all planning docs with the feature-slice approach. Also trims agent config based on review of redundant rules.

## Changes

- **Phase 1 context**: Create 01-CONTEXT.md with architectural decisions (TransactionLike convention, getHeader removal, headerDeps approach); update STATE.md
- **Planning docs reconciliation**: Align ROADMAP, REQUIREMENTS, research, and codebase docs with phase 1 decisions and feature-slice approach
- **Codebase docs**: Correct pnpm-workspace.yaml listing, .pnpmfile.cjs description, ccc-dev directory structure
- **Agent config**: Add CLAUDE.md symlink note, Knowledge section, clickable PR links; remove redundant rules
- **Lockfile**: Dependency version bumps