### PR TITLE
Harden core runtime safety checks

### DIFF
--- a/apps/interface/src/Form.tsx
+++ b/apps/interface/src/Form.tsx
@@ -3,8 +3,8 @@ import { IckbSdk, type SystemState } from "@ickb/sdk";
 import {
   CKB,
   direction2Symbol,
-  reservedCKB,
   sanitizeAmountInput,
+  spendableCkb,
   symbol2Direction,
   toText,
 } from "./utils.ts";
@@ -41,8 +41,8 @@ export default function Form({
     setRawText(direction2Symbol(!isCkb2Udt) + text);
   };
 
-  const spendableCkb = ckbAvailable > reservedCKB ? ckbAvailable - reservedCKB : 0n;
-  const nativeCkb = spendableCkb < ckbNative ? spendableCkb : ckbNative;
+  const maxCkb = spendableCkb(ckbAvailable);
+  const nativeCkb = maxCkb < ckbNative ? maxCkb : ckbNative;
 
   let a = {
     name: "CKB",

--- a/apps/interface/src/queries.ts
+++ b/apps/interface/src/queries.ts
@@ -1,5 +1,5 @@
 import {
-  projectAccountAvailability,
+  projectConversionTransactionContext,
   type SystemState,
 } from "@ickb/sdk";
 import {
@@ -88,7 +88,7 @@ export async function getL1State(
     walletConfig.accountLocks,
   );
   const { system, user, account } = sdkState;
-  const projection = projectAccountAvailability(account, user.orders, {
+  const { projection, context: conversionContext } = projectConversionTransactionContext(system, account, user.orders, {
     collectedOrdersAvailable: true,
   });
   const hasMatchable = user.orders.some((group) => group.order.isMatchable());
@@ -99,30 +99,14 @@ export async function getL1State(
     ickbBalance,
     ckbAvailable,
     ickbAvailable,
-    readyWithdrawals,
     pendingWithdrawals,
-    availableOrders,
     pendingOrders,
   } = projection;
 
-  const estimatedMaturity = [
-    system.tip.timestamp,
-    ...pendingWithdrawals.map((group) => group.owned.maturity.toUnix(system.tip)),
-    ...pendingOrders
-      .map((group) => group.order.maturity)
-      .filter((maturity): maturity is bigint => maturity !== undefined),
-  ].reduce((best, maturity) => (best > maturity ? best : maturity));
-
   const txContext: TransactionContext = {
-    system,
+    ...conversionContext,
     capacityCells: account.capacityCells,
     nativeUdtCells: account.nativeUdtCells,
-    receipts: account.receipts,
-    readyWithdrawals,
-    availableOrders,
-    ckbAvailable,
-    ickbAvailable,
-    estimatedMaturity,
   };
 
   return {

--- a/apps/interface/src/transaction.test.ts
+++ b/apps/interface/src/transaction.test.ts
@@ -8,7 +8,7 @@ import { byte32FromByte } from "@ickb/testkit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildTransactionPreview } from "./transaction.ts";
 import type { TransactionContext } from "./transaction.ts";
-import type { WalletConfig } from "./utils.ts";
+import { CKB, reservedCKB, type WalletConfig } from "./utils.ts";
 
 type BuildConversionTransactionMock = ReturnType<
   typeof vi.fn<WalletConfig["sdk"]["buildConversionTransaction"]>
@@ -134,6 +134,8 @@ describe("buildTransactionPreview", () => {
       .resolves.toMatchObject({ error: "Amount must be positive" });
     await expect(buildTransactionPreview(context({ ckbAvailable: 1n }), true, 2n, config))
       .resolves.toMatchObject({ error: "Not enough CKB" });
+    await expect(buildTransactionPreview(context({ ckbAvailable: reservedCKB + CKB }), true, reservedCKB + CKB, config))
+      .resolves.toMatchObject({ error: "Not enough CKB" });
     await expect(buildTransactionPreview(context({ ickbAvailable: 1n }), false, 2n, config))
       .resolves.toMatchObject({ error: "Not enough iCKB" });
     expect(buildConversionTransaction).not.toHaveBeenCalled();
@@ -156,7 +158,7 @@ describe("buildTransactionPreview", () => {
     const completeTransaction = completeTransactionMock();
     vi.spyOn(ccc.Transaction.prototype, "getFee").mockResolvedValue(42n);
     const txContext = context({
-      ckbAvailable: 7n,
+      ckbAvailable: reservedCKB + 7n,
       system: { ...context().system, feeRate: 9n },
     });
     const config = walletConfigWith({
@@ -215,7 +217,7 @@ describe("buildTransactionPreview", () => {
         sdk: { buildConversionTransaction: buildConversionTransactionMock(failedPlan(reason, 77n)) },
       });
 
-      await expect(buildTransactionPreview(context({ ckbAvailable: 1n }), true, 1n, config))
+      await expect(buildTransactionPreview(context({ ckbAvailable: reservedCKB + 1n }), true, 1n, config))
         .resolves.toMatchObject({ error: message, estimatedMaturity: 77n });
     }
   });
@@ -242,7 +244,7 @@ describe("buildTransactionPreview", () => {
     vi.spyOn(ccc.Transaction.prototype, "getFee").mockResolvedValue(1n);
 
     await buildTransactionPreview(
-      context({ ckbAvailable: 1n }),
+      context({ ckbAvailable: reservedCKB + 1n }),
       true,
       1n,
       walletConfigWith({
@@ -264,7 +266,7 @@ describe("buildTransactionPreview", () => {
           .mockRejectedValue(new Error("planner failed")),
       },
     });
-    await expect(buildTransactionPreview(context({ ckbAvailable: 1n }), true, 1n, plannerFailure))
+    await expect(buildTransactionPreview(context({ ckbAvailable: reservedCKB + 1n }), true, 1n, plannerFailure))
       .resolves.toMatchObject({ error: "planner failed" });
 
     const completionFailure = walletConfigWith({
@@ -274,7 +276,7 @@ describe("buildTransactionPreview", () => {
           .mockRejectedValue(new Error("completion failed")),
       },
     });
-    await expect(buildTransactionPreview(context({ ckbAvailable: 1n }), true, 1n, completionFailure))
+    await expect(buildTransactionPreview(context({ ckbAvailable: reservedCKB + 1n }), true, 1n, completionFailure))
       .resolves.toMatchObject({ error: "completion failed" });
   });
 });

--- a/apps/interface/src/transaction.ts
+++ b/apps/interface/src/transaction.ts
@@ -5,6 +5,7 @@ import {
 } from "@ickb/sdk";
 import {
   errorMessageOf,
+  spendableCkb,
   txInfoPadding,
   type TxInfo,
   type WalletConfig,
@@ -26,7 +27,7 @@ export async function buildTransactionPreview(
       return txInfoWithError("Amount must be positive", context.estimatedMaturity);
     }
 
-    if (isCkb2Udt && amount > context.ckbAvailable) {
+    if (isCkb2Udt && amount > spendableCkb(context.ckbAvailable)) {
       return txInfoWithError("Not enough CKB", context.estimatedMaturity);
     }
 

--- a/apps/interface/src/utils.ts
+++ b/apps/interface/src/utils.ts
@@ -49,6 +49,10 @@ export const CKB = ccc.fixedPointFrom(1);
 // reservedCKB are reserved for state rent in conversions
 export const reservedCKB = 600n * CKB;
 
+export function spendableCkb(ckbAvailable: bigint): bigint {
+  return ckbAvailable > reservedCKB ? ckbAvailable - reservedCKB : 0n;
+}
+
 export function parseWalletChain(walletChain: string): WalletChainParts {
   const separatorIndex = walletChain.lastIndexOf("_");
   if (separatorIndex <= 0 || separatorIndex === walletChain.length - 1) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "forks:ccc:plan": "node scripts/forks-ccc.mjs --plan",
     "forks:ccc:smoke": "node scripts/forks-ccc-smoke.mjs",
     "forks:ccc:watch": "node scripts/forks-ccc.mjs --watch",
+    "live:generate-config": "node scripts/ickb-generate-config.mjs",
+    "live:preflight": "node scripts/ickb-live-preflight.mjs",
     "coworker:ask": "opencode run --pure --agent plan"
   },
   "engines": {

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -323,6 +323,24 @@ describe("node utilities", () => {
     await expect(verifyChainPreflight(client, "testnet")).rejects.not.toThrow(/\buser\b|\bpass\b/u);
   });
 
+  it("redacts non-Error preflight failures without losing thrown values", async () => {
+    const client = preflightClient({
+      addressPrefix: "ckt",
+      genesisHash: CHAIN_IDENTITIES.testnet.genesisHash,
+      tipHash: byte32FromByte("22"),
+      tipNumber: 123n,
+      tipTimestamp: 456n,
+      url: "https://testnet.example/rpc/path?token=secret",
+    });
+    client.getHeaderByNumber = (): Promise<ccc.ClientBlockHeader | undefined> => {
+      throw { reason: "failed", amount: 9007199254740993n, token: "secret" };
+    };
+
+    await expect(verifyChainPreflight(client, "testnet")).rejects.toThrow(
+      '{"reason":"failed","amount":"9007199254740993","token":"<redacted-rpc-query>"}',
+    );
+  });
+
   it("redacts credential-bearing RPC URLs", () => {
     expect(redactRpcUrl("https://rpc.example/")).toBe("https://rpc.example/");
     expect(redactRpcUrl("https://rpc.example/path?token=abc&key=def")).toBe(
@@ -354,6 +372,16 @@ describe("node utilities", () => {
     )).toBe(
       "fetch failed for token=<redacted-rpc-query> decoded=<redacted-rpc-query> " +
         "plain=<redacted-rpc-query>",
+    );
+    expect(redactSecretText("empty secrets stay intact", { privateKey: "", rpcUrl: "" })).toBe(
+      "empty secrets stay intact",
+    );
+    expect(redactSecretText(
+      "fetch failed for https://%E0%A4%A@testnet.example/rpc?token=secret %E0%A4%A",
+      { rpcUrl: "https://%E0%A4%A@testnet.example/rpc?token=secret" },
+    )).toBe(
+      "fetch failed for https://redacted@testnet.example/...?token=redacted " +
+        "<redacted-rpc-username>",
     );
   });
 

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -333,7 +333,12 @@ describe("node utilities", () => {
       url: "https://testnet.example/rpc/path?token=secret",
     });
     client.getHeaderByNumber = (): Promise<ccc.ClientBlockHeader | undefined> => {
-      throw { reason: "failed", amount: 9007199254740993n, token: "secret" };
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- Covers defensive handling for non-Error RPC failures.
+      return Promise.reject({
+        reason: "failed",
+        amount: 9007199254740993n,
+        token: "secret",
+      });
     };
 
     await expect(verifyChainPreflight(client, "testnet")).rejects.toThrow(

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -420,11 +420,20 @@ describe("node utilities", () => {
     const privateKey = `0x${"11".repeat(32)}`;
     const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
     const executionLog: Record<string, unknown> = {};
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
 
     expect(handleLoopError(executionLog, {
-      message: `failed for ${privateKey}`,
+      message: `failed for ${privateKey} via ${rpcUrl}`,
+      privateKey,
       rpcUrl,
       amount: 9007199254740993n,
+      nested: {
+        private_key: privateKey,
+        rpc_url: rpcUrl,
+        message: `nested ${privateKey}`,
+      },
+      circular,
     }, { privateKey, rpcUrl })).toBe(false);
     const serialized = JSON.stringify(executionLog);
 
@@ -433,7 +442,17 @@ describe("node utilities", () => {
     expect(serialized).not.toContain("secret");
     expect(serialized).toContain("<redacted-private-key>");
     expect(serialized).toContain("https://redacted:redacted@testnet.example/...?token=redacted");
-    expect(executionLog.error).toMatchObject({ amount: "9007199254740993" });
+    expect(executionLog.error).toMatchObject({
+      message: "failed for <redacted-private-key> via " +
+        "https://redacted:redacted@testnet.example/...?token=redacted",
+      amount: "9007199254740993",
+      nested: { message: "nested <redacted-private-key>" },
+      circular: { self: "[Circular]" },
+    });
+    expect(executionLog.error).not.toHaveProperty("rpcUrl");
+    expect(executionLog.error).not.toHaveProperty("privateKey");
+    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("rpc_url");
+    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("private_key");
   });
 
   it("logs one JSON entry with elapsed seconds", () => {

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -476,6 +476,7 @@ describe("node utilities", () => {
         private_key: privateKey,
         rpc_url: rpcUrl,
         password: "hunter2",
+        apiKey: "api-key-value",
         accessToken: "secret-token",
         api_secret: "secret-value",
         message: `nested ${privateKey}`,
@@ -501,6 +502,7 @@ describe("node utilities", () => {
     expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("rpc_url");
     expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("private_key");
     expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("password");
+    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("apiKey");
     expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("accessToken");
     expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("api_secret");
   });

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -1,11 +1,13 @@
 import { ccc } from "@ckb-ccc/core";
-import { byte32FromByte, script } from "@ickb/testkit";
+import { byte32FromByte, headerLike, script } from "@ickb/testkit";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import process from "node:process";
 import { tmpdir } from "node:os";
 import { describe, expect, it, vi } from "vitest";
 import {
+  assertChainPreflight,
+  CHAIN_IDENTITIES,
   createPublicClient,
   formatCkb,
   handleLoopError,
@@ -16,10 +18,15 @@ import {
   readRuntimeConfigEnv,
   parseSleepInterval,
   randomSleepIntervalMs,
+  readChainPreflight,
+  redactRpcUrl,
+  redactSecretText,
   reachedMaxIterations,
   signerAccountLocks,
   STOP_EXIT_CODE,
+  verifyChainPreflight,
   writeJsonLine,
+  type ChainPreflightClient,
 } from "./index.js";
 
 describe("node utilities", () => {
@@ -74,6 +81,7 @@ describe("node utilities", () => {
 
   it("parses private keys as exact 0x-prefixed lowercase hex", () => {
     const privateKey = `0x${"11".repeat(32)}`;
+    const secp256k1Order = "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141";
 
     expect(parsePrivateKey(privateKey, "BOT_CONFIG_FILE")).toBe(privateKey);
     for (const value of [
@@ -83,6 +91,9 @@ describe("node utilities", () => {
       ` 0x${"11".repeat(32)}`,
       `0x${"11".repeat(32)} `,
       `0x${"11".repeat(31)}`,
+      `0x${"00".repeat(32)}`,
+      secp256k1Order,
+      "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
     ]) {
       expect(() => parsePrivateKey(value, "BOT_CONFIG_FILE")).toThrow(
         "Invalid env BOT_CONFIG_FILE",
@@ -148,6 +159,7 @@ describe("node utilities", () => {
   it("reads runtime JSON config from a file env source", async () => {
     const privateKey = `0x${"11".repeat(32)}`;
     const dir = await mkdtemp(join(tmpdir(), "ickb-runtime-config-"));
+    const originalInitCwd = process.env.INIT_CWD;
     try {
       const configPath = join(dir, "config.json");
       await writeFile(configPath, JSON.stringify({
@@ -170,7 +182,20 @@ describe("node utilities", () => {
       await expect(readRuntimeConfigEnv(join(dir, "missing"), "BOT_CONFIG_FILE")).rejects.toThrow(
         "Invalid file from env BOT_CONFIG_FILE",
       );
+      process.env.INIT_CWD = dir;
+      await expect(readRuntimeConfigEnv("config.json", "BOT_CONFIG_FILE")).resolves.toMatchObject({
+        chain: "testnet",
+        privateKey,
+      });
+      await expect(readRuntimeConfigEnv(resolve("config.json"), "BOT_CONFIG_FILE")).rejects.toThrow(
+        "Invalid file from env BOT_CONFIG_FILE",
+      );
     } finally {
+      if (originalInitCwd === undefined) {
+        delete process.env.INIT_CWD;
+      } else {
+        process.env.INIT_CWD = originalInitCwd;
+      }
       await rm(dir, { recursive: true, force: true });
     }
   });
@@ -202,6 +227,133 @@ describe("node utilities", () => {
     expect(testnet.addressPrefix).toBe("ckt");
     expect((mainnet as ccc.ClientPublicMainnet).url).toBe(
       "https://mainnet.example",
+    );
+  });
+
+  it("pins official CKB chain identities for preflight checks", () => {
+    expect(CHAIN_IDENTITIES.mainnet).toMatchObject({
+      chain: "mainnet",
+      networkName: "ckb",
+      genesisHash: "0x92b197aa1fba0f63633922c61c92375c9c074a93e85963554f5499fe1450d0e5",
+      genesisMessage: "lina 0x18e020f6b1237a3d06b75121f25a7efa0550e4b3f44f974822f471902424c104",
+      genesisSource: "https://raw.githubusercontent.com/nervosnetwork/ckb/develop/resource/specs/mainnet.toml",
+      addressPrefix: "ckb",
+    });
+    expect(CHAIN_IDENTITIES.testnet).toMatchObject({
+      chain: "testnet",
+      networkName: "ckb_testnet",
+      genesisHash: "0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606",
+      genesisMessage: "aggron-v4",
+      genesisSource: "https://raw.githubusercontent.com/nervosnetwork/ckb/develop/resource/specs/testnet.toml",
+      addressPrefix: "ckt",
+    });
+  });
+
+  it("reads and verifies public chain identity evidence", async () => {
+    const client = preflightClient({
+      addressPrefix: "ckt",
+      genesisHash: CHAIN_IDENTITIES.testnet.genesisHash,
+      tipHash: byte32FromByte("22"),
+      tipNumber: 123n,
+      tipTimestamp: 456n,
+      url: "https://user:pass@testnet.example/rpc/path?token=secret&plain=value",
+    });
+
+    await expect(readChainPreflight(client, "testnet")).resolves.toEqual({
+      chain: "testnet",
+      redactedRpcUrl: "https://redacted:redacted@testnet.example/...?token=redacted&plain=redacted",
+      expected: CHAIN_IDENTITIES.testnet,
+      observed: {
+        genesisHash: CHAIN_IDENTITIES.testnet.genesisHash,
+        addressPrefix: "ckt",
+        tip: {
+          hash: byte32FromByte("22"),
+          number: 123n,
+          timestamp: 456n,
+        },
+      },
+      matches: {
+        genesisHash: true,
+        addressPrefix: true,
+      },
+    });
+    await expect(verifyChainPreflight(client, "testnet")).resolves.toMatchObject({
+      chain: "testnet",
+      matches: { genesisHash: true, addressPrefix: true },
+    });
+  });
+
+  it("rejects mismatched public chain identity evidence", () => {
+    expect(() => assertChainPreflight({
+      chain: "testnet",
+      redactedRpcUrl: "https://rpc.example/",
+      expected: CHAIN_IDENTITIES.testnet,
+      observed: {
+        genesisHash: CHAIN_IDENTITIES.mainnet.genesisHash,
+        addressPrefix: "ckb",
+        tip: { hash: byte32FromByte("22"), number: 1n, timestamp: 2n },
+      },
+      matches: { genesisHash: false, addressPrefix: false },
+    })).toThrow(
+      "Invalid testnet RPC chain identity: genesis hash expected " +
+        CHAIN_IDENTITIES.testnet.genesisHash +
+        " observed " +
+        CHAIN_IDENTITIES.mainnet.genesisHash +
+        "; address prefix expected ckt observed ckb",
+    );
+  });
+
+  it("redacts RPC URLs when chain preflight reads fail", async () => {
+    const client = preflightClient({
+      addressPrefix: "ckt",
+      genesisHash: CHAIN_IDENTITIES.testnet.genesisHash,
+      tipHash: byte32FromByte("22"),
+      tipNumber: 123n,
+      tipTimestamp: 456n,
+      url: "https://user:pass@testnet.example/rpc/path?token=secret",
+    });
+    client.getHeaderByNumber = (): Promise<ccc.ClientBlockHeader | undefined> => {
+      throw new Error("RPC failed: https://user:pass@testnet.example/rpc/path?token=secret user pass secret");
+    };
+
+    await expect(verifyChainPreflight(client, "testnet")).rejects.toThrow(
+      "RPC failed: https://redacted:redacted@testnet.example/...?token=redacted",
+    );
+    await expect(verifyChainPreflight(client, "testnet")).rejects.not.toThrow(/secret|user:pass/u);
+    await expect(verifyChainPreflight(client, "testnet")).rejects.not.toThrow(/\buser\b|\bpass\b/u);
+  });
+
+  it("redacts credential-bearing RPC URLs", () => {
+    expect(redactRpcUrl("https://rpc.example/")).toBe("https://rpc.example/");
+    expect(redactRpcUrl("https://rpc.example/path?token=abc&key=def")).toBe(
+      "https://rpc.example/...?token=redacted&key=redacted",
+    );
+    expect(redactRpcUrl("not a url")).toBe("<invalid-url>");
+  });
+
+  it("redacts runtime secrets from text", () => {
+    const privateKey = `0x${"11".repeat(32)}`;
+    const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
+
+    expect(redactSecretText(
+      `failed for ${privateKey} via ${rpcUrl}`,
+      { privateKey, rpcUrl },
+    )).toBe(
+      "failed for <redacted-private-key> via https://redacted:redacted@testnet.example/...?token=redacted",
+    );
+    expect(redactSecretText(
+      "fetch failed for https://testnet.example/rpc/path?token=secret auth user:pass",
+      { rpcUrl },
+    )).toBe(
+      "fetch failed for https://testnet.example/rpc/path?token=<redacted-rpc-query> auth " +
+        "<redacted-rpc-username>:<redacted-rpc-password>",
+    );
+    expect(redactSecretText(
+      "fetch failed for token=a%2Fb decoded=a/b plain=value",
+      { rpcUrl: "https://testnet.example/rpc/path?token=a%2Fb&plain=value" },
+    )).toBe(
+      "fetch failed for token=<redacted-rpc-query> decoded=<redacted-rpc-query> " +
+        "plain=<redacted-rpc-query>",
     );
   });
 
@@ -245,6 +397,43 @@ describe("node utilities", () => {
     });
 
     process.exitCode = undefined;
+  });
+
+  it("redacts runtime secrets from loop errors", () => {
+    const privateKey = `0x${"11".repeat(32)}`;
+    const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
+    const error = new Error(`failed for ${privateKey} via ${rpcUrl}`);
+    error.stack = `stack with ${privateKey} and ${rpcUrl}`;
+    const executionLog: Record<string, unknown> = {};
+
+    expect(handleLoopError(executionLog, error, { privateKey, rpcUrl })).toBe(false);
+    const serialized = JSON.stringify(executionLog);
+
+    expect(serialized).not.toContain(privateKey);
+    expect(serialized).not.toContain("user:pass");
+    expect(serialized).not.toContain("secret");
+    expect(serialized).toContain("<redacted-private-key>");
+    expect(serialized).toContain("https://redacted:redacted@testnet.example/...?token=redacted");
+  });
+
+  it("redacts runtime secrets from non-Error loop failures", () => {
+    const privateKey = `0x${"11".repeat(32)}`;
+    const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
+    const executionLog: Record<string, unknown> = {};
+
+    expect(handleLoopError(executionLog, {
+      message: `failed for ${privateKey}`,
+      rpcUrl,
+      amount: 9007199254740993n,
+    }, { privateKey, rpcUrl })).toBe(false);
+    const serialized = JSON.stringify(executionLog);
+
+    expect(serialized).not.toContain(privateKey);
+    expect(serialized).not.toContain("user:pass");
+    expect(serialized).not.toContain("secret");
+    expect(serialized).toContain("<redacted-private-key>");
+    expect(serialized).toContain("https://redacted:redacted@testnet.example/...?token=redacted");
+    expect(executionLog.error).toMatchObject({ amount: "9007199254740993" });
   });
 
   it("logs one JSON entry with elapsed seconds", () => {
@@ -347,4 +536,36 @@ function transactionError(isTimeout: boolean, txHash = byte32FromByte("11")): Er
     status: isTimeout ? "sent" : "rejected",
     isTimeout,
   });
+}
+
+function preflightClient({
+  addressPrefix,
+  genesisHash,
+  tipHash,
+  tipNumber,
+  tipTimestamp,
+  url,
+}: {
+  addressPrefix: string;
+  genesisHash: `0x${string}`;
+  tipHash: `0x${string}`;
+  tipNumber: bigint;
+  tipTimestamp: bigint;
+  url: string;
+}): ChainPreflightClient {
+  return {
+    addressPrefix,
+    url,
+    getHeaderByNumber: async (blockNumber): Promise<ccc.ClientBlockHeader | undefined> => {
+      await Promise.resolve();
+      if (blockNumber !== 0n) {
+        return;
+      }
+      return headerLike({ hash: genesisHash, number: 0n });
+    },
+    getTipHeader: async (): Promise<ccc.ClientBlockHeader> => {
+      await Promise.resolve();
+      return headerLike({ hash: tipHash, number: tipNumber, timestamp: tipTimestamp });
+    },
+  };
 }

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -337,8 +337,14 @@ describe("node utilities", () => {
     };
 
     await expect(verifyChainPreflight(client, "testnet")).rejects.toThrow(
-      '{"reason":"failed","amount":"9007199254740993","token":"<redacted-rpc-query>"}',
+      '{"reason":"failed","amount":"9007199254740993"}',
     );
+    await expect(verifyChainPreflight(client, "testnet")).rejects.toMatchObject({
+      cause: {
+        reason: "failed",
+        amount: "9007199254740993",
+      },
+    });
   });
 
   it("redacts credential-bearing RPC URLs", () => {
@@ -430,8 +436,11 @@ describe("node utilities", () => {
   it("redacts runtime secrets from loop errors", () => {
     const privateKey = `0x${"11".repeat(32)}`;
     const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
-    const error = new Error(`failed for ${privateKey} via ${rpcUrl}`);
+    const error = new Error(`failed for ${privateKey} via ${rpcUrl}`, {
+      cause: new Error(`nested ${privateKey} via ${rpcUrl}`),
+    });
     error.stack = `stack with ${privateKey} and ${rpcUrl}`;
+    (error.cause as Error).stack = `nested stack with ${privateKey} and ${rpcUrl}`;
     const executionLog: Record<string, unknown> = {};
 
     expect(handleLoopError(executionLog, error, { privateKey, rpcUrl })).toBe(false);
@@ -442,6 +451,13 @@ describe("node utilities", () => {
     expect(serialized).not.toContain("secret");
     expect(serialized).toContain("<redacted-private-key>");
     expect(serialized).toContain("https://redacted:redacted@testnet.example/...?token=redacted");
+    expect(executionLog.error).toMatchObject({
+      cause: {
+        name: "Error",
+        message: "nested <redacted-private-key> via " +
+          "https://redacted:redacted@testnet.example/...?token=redacted",
+      },
+    });
   });
 
   it("redacts runtime secrets from non-Error loop failures", () => {
@@ -459,6 +475,9 @@ describe("node utilities", () => {
       nested: {
         private_key: privateKey,
         rpc_url: rpcUrl,
+        password: "hunter2",
+        accessToken: "secret-token",
+        api_secret: "secret-value",
         message: `nested ${privateKey}`,
       },
       circular,
@@ -481,6 +500,9 @@ describe("node utilities", () => {
     expect(executionLog.error).not.toHaveProperty("privateKey");
     expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("rpc_url");
     expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("private_key");
+    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("password");
+    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("accessToken");
+    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("api_secret");
   });
 
   it("logs one JSON entry with elapsed seconds", () => {

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -539,7 +539,7 @@ function sanitizeLogValue(
 
 function isSensitiveLogKey(key: string): boolean {
   const normalized = key.toLowerCase().replace(/[-_]/gu, "");
-  return ["privatekey", "rpcurl", "password", "token", "secret"].some(
+  return ["privatekey", "rpcurl", "apikey", "password", "token", "secret"].some(
     (sensitiveKey) => normalized === sensitiveKey || normalized.endsWith(sensitiveKey),
   );
 }

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -135,20 +135,35 @@ export async function verifyChainPreflight(
 }
 
 function redactRpcUrlInError(error: unknown, rpcUrl: string): string {
-  const message = error instanceof Error ? error.message : "Unknown error";
+  const message = typeof error === "string"
+    ? error
+    : error instanceof Error
+      ? error.message
+      : stringifyErrorMessage(error);
   return redactSecretText(message, { rpcUrl });
 }
 
 export function redactSecretText(text: string, secrets: SecretRedactionContext = {}): string {
   let redacted = text;
-  if (secrets.privateKey !== undefined) {
+  if (secrets.privateKey) {
     redacted = redacted.split(secrets.privateKey).join("<redacted-private-key>");
   }
-  if (secrets.rpcUrl !== undefined) {
+  if (secrets.rpcUrl) {
     redacted = redacted.split(secrets.rpcUrl).join(secrets.redactedRpcUrl ?? redactRpcUrl(secrets.rpcUrl));
     redacted = redactRpcUrlSecrets(redacted, secrets.rpcUrl);
   }
   return redacted;
+}
+
+function stringifyErrorMessage(error: unknown): string {
+  if (error === undefined || error === null) {
+    return "Unknown error";
+  }
+  try {
+    return JSON.stringify(error, jsonLogReplacer);
+  } catch {
+    return String(error);
+  }
 }
 
 function redactRpcUrlSecrets(text: string, rpcUrl: string): string {
@@ -162,11 +177,11 @@ function redactRpcUrlSecrets(text: string, rpcUrl: string): string {
   const replacements = new Array<[string, string]>();
   if (url.username !== "") {
     replacements.push([url.username, "<redacted-rpc-username>"]);
-    replacements.push([decodeURIComponent(url.username), "<redacted-rpc-username>"]);
+    replacements.push([safeDecodeURIComponent(url.username), "<redacted-rpc-username>"]);
   }
   if (url.password !== "") {
     replacements.push([url.password, "<redacted-rpc-password>"]);
-    replacements.push([decodeURIComponent(url.password), "<redacted-rpc-password>"]);
+    replacements.push([safeDecodeURIComponent(url.password), "<redacted-rpc-password>"]);
   }
   for (const value of url.searchParams.values()) {
     replacements.push([value, "<redacted-rpc-query>"]);
@@ -198,6 +213,14 @@ function replaceUrlSecrets(text: string, replacements: Array<[string, string]>):
     .map(escapeRegExp)
     .join("|");
   return text.replace(new RegExp(pattern, "gu"), (match) => unique.get(match) ?? match);
+}
+
+function safeDecodeURIComponent(text: string): string {
+  try {
+    return decodeURIComponent(text);
+  } catch {
+    return "";
+  }
 }
 
 function escapeRegExp(text: string): string {

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -1,14 +1,234 @@
 import { ccc } from "@ckb-ccc/core";
 import { unique } from "@ickb/utils";
 import { readFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
 import process from "node:process";
 import { setTimeout } from "node:timers";
 
 const CKB = 100000000n;
+const SECP256K1_ORDER = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
 
 export const STOP_EXIT_CODE = 2;
 
 export type SupportedChain = "mainnet" | "testnet";
+
+export interface ChainIdentity {
+  chain: SupportedChain;
+  networkName: string;
+  genesisHash: ccc.Hex;
+  genesisMessage: string;
+  genesisSource: string;
+  addressPrefix: "ckb" | "ckt";
+}
+
+export const CHAIN_IDENTITIES = {
+  mainnet: {
+    chain: "mainnet",
+    networkName: "ckb",
+    genesisHash: "0x92b197aa1fba0f63633922c61c92375c9c074a93e85963554f5499fe1450d0e5",
+    genesisMessage: "lina 0x18e020f6b1237a3d06b75121f25a7efa0550e4b3f44f974822f471902424c104",
+    genesisSource: "https://raw.githubusercontent.com/nervosnetwork/ckb/develop/resource/specs/mainnet.toml",
+    addressPrefix: "ckb",
+  },
+  testnet: {
+    chain: "testnet",
+    networkName: "ckb_testnet",
+    genesisHash: "0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606",
+    genesisMessage: "aggron-v4",
+    genesisSource: "https://raw.githubusercontent.com/nervosnetwork/ckb/develop/resource/specs/testnet.toml",
+    addressPrefix: "ckt",
+  },
+} as const satisfies Record<SupportedChain, ChainIdentity>;
+
+export type ChainPreflightClient = Pick<
+  ccc.Client,
+  "addressPrefix" | "getHeaderByNumber" | "getTipHeader" | "url"
+>;
+
+export interface ChainPreflightEvidence {
+  chain: SupportedChain;
+  redactedRpcUrl: string;
+  expected: ChainIdentity;
+  observed: {
+    genesisHash: ccc.Hex;
+    addressPrefix: string;
+    tip: {
+      hash: ccc.Hex;
+      number: bigint;
+      timestamp: bigint;
+    };
+  };
+  matches: {
+    genesisHash: boolean;
+    addressPrefix: boolean;
+  };
+}
+
+export function expectedChainIdentity(chain: SupportedChain): ChainIdentity {
+  return CHAIN_IDENTITIES[chain];
+}
+
+export async function readChainPreflight(
+  client: ChainPreflightClient,
+  chain: SupportedChain,
+): Promise<ChainPreflightEvidence> {
+  const expected = expectedChainIdentity(chain);
+  const [genesis, tip] = await Promise.all([
+    client.getHeaderByNumber(0n),
+    client.getTipHeader(),
+  ]);
+
+  if (genesis === undefined) {
+    throw new Error(`Missing ${chain} genesis header`);
+  }
+
+  return {
+    chain,
+    redactedRpcUrl: redactRpcUrl(client.url),
+    expected,
+    observed: {
+      genesisHash: genesis.hash,
+      addressPrefix: client.addressPrefix,
+      tip: {
+        hash: tip.hash,
+        number: tip.number,
+        timestamp: tip.timestamp,
+      },
+    },
+    matches: {
+      genesisHash: genesis.hash === expected.genesisHash,
+      addressPrefix: client.addressPrefix === expected.addressPrefix,
+    },
+  };
+}
+
+export function assertChainPreflight(
+  evidence: ChainPreflightEvidence,
+): ChainPreflightEvidence {
+  const failures: string[] = [];
+  if (evidence.observed.genesisHash !== evidence.expected.genesisHash) {
+    failures.push(
+      `genesis hash expected ${evidence.expected.genesisHash} observed ${evidence.observed.genesisHash}`,
+    );
+  }
+  if (evidence.observed.addressPrefix !== evidence.expected.addressPrefix) {
+    failures.push(
+      `address prefix expected ${evidence.expected.addressPrefix} observed ${evidence.observed.addressPrefix}`,
+    );
+  }
+  if (failures.length > 0) {
+    throw new Error(`Invalid ${evidence.chain} RPC chain identity: ${failures.join("; ")}`);
+  }
+
+  return evidence;
+}
+
+export async function verifyChainPreflight(
+  client: ChainPreflightClient,
+  chain: SupportedChain,
+): Promise<ChainPreflightEvidence> {
+  try {
+    return assertChainPreflight(await readChainPreflight(client, chain));
+  } catch (error) {
+    throw new Error(redactRpcUrlInError(error, client.url));
+  }
+}
+
+function redactRpcUrlInError(error: unknown, rpcUrl: string): string {
+  const message = error instanceof Error ? error.message : "Unknown error";
+  return redactSecretText(message, { rpcUrl });
+}
+
+export function redactSecretText(text: string, secrets: SecretRedactionContext = {}): string {
+  let redacted = text;
+  if (secrets.privateKey !== undefined) {
+    redacted = redacted.split(secrets.privateKey).join("<redacted-private-key>");
+  }
+  if (secrets.rpcUrl !== undefined) {
+    redacted = redacted.split(secrets.rpcUrl).join(secrets.redactedRpcUrl ?? redactRpcUrl(secrets.rpcUrl));
+    redacted = redactRpcUrlSecrets(redacted, secrets.rpcUrl);
+  }
+  return redacted;
+}
+
+function redactRpcUrlSecrets(text: string, rpcUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rpcUrl);
+  } catch {
+    return text;
+  }
+
+  const replacements = new Array<[string, string]>();
+  if (url.username !== "") {
+    replacements.push([url.username, "<redacted-rpc-username>"]);
+    replacements.push([decodeURIComponent(url.username), "<redacted-rpc-username>"]);
+  }
+  if (url.password !== "") {
+    replacements.push([url.password, "<redacted-rpc-password>"]);
+    replacements.push([decodeURIComponent(url.password), "<redacted-rpc-password>"]);
+  }
+  for (const value of url.searchParams.values()) {
+    replacements.push([value, "<redacted-rpc-query>"]);
+  }
+  for (const value of rawSearchParamValues(url.search)) {
+    replacements.push([value, "<redacted-rpc-query>"]);
+  }
+  return replaceUrlSecrets(text, replacements);
+}
+
+function rawSearchParamValues(search: string): string[] {
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  if (query === "") {
+    return [];
+  }
+  return query.split("&").map((part) => {
+    const separator = part.indexOf("=");
+    return separator === -1 ? "" : part.slice(separator + 1);
+  });
+}
+
+function replaceUrlSecrets(text: string, replacements: Array<[string, string]>): string {
+  const unique = new Map(replacements.filter(([secret]) => secret !== ""));
+  if (unique.size === 0) {
+    return text;
+  }
+  const pattern = [...unique.keys()]
+    .sort((left, right) => right.length - left.length)
+    .map(escapeRegExp)
+    .join("|");
+  return text.replace(new RegExp(pattern, "gu"), (match) => unique.get(match) ?? match);
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+export function redactRpcUrl(rpcUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rpcUrl);
+  } catch {
+    return "<invalid-url>";
+  }
+
+  if (url.username !== "" || url.password !== "") {
+    url.username = "redacted";
+    url.password = url.password === "" ? "" : "redacted";
+  }
+  if (url.pathname !== "" && url.pathname !== "/") {
+    url.pathname = "/...";
+  }
+  if (url.search !== "") {
+    const redactedParams = new URLSearchParams();
+    for (const [key] of url.searchParams) {
+      redactedParams.append(key, "redacted");
+    }
+    url.search = redactedParams.toString();
+  }
+
+  return url.toString();
+}
 
 export function formatCkb(balance: bigint): string {
   const sign = balance < 0n ? "-" : "";
@@ -40,7 +260,10 @@ export function parseSleepInterval(
 
 export function parsePrivateKey(privateKey: string, envName: string): `0x${string}` {
   if (/^0x[0-9a-f]{64}$/u.test(privateKey)) {
-    return privateKey as `0x${string}`;
+    const value = BigInt(privateKey);
+    if (value > 0n && value < SECP256K1_ORDER) {
+      return privateKey as `0x${string}`;
+    }
   }
 
   throw new Error("Invalid env " + envName);
@@ -53,6 +276,12 @@ export type RuntimeConfig = {
   sleepIntervalMs: number;
   maxIterations: number | undefined;
 };
+
+export interface SecretRedactionContext {
+  privateKey?: string;
+  rpcUrl?: string;
+  redactedRpcUrl?: string;
+}
 
 export function parseRpcUrl(rpcUrl: string, envName: string): string {
   for (let index = 0; index < rpcUrl.length; index += 1) {
@@ -163,7 +392,9 @@ export async function readRuntimeConfigEnv(
 }
 
 async function readFileEnv(fileEnvValue: string, fileEnvName: string): Promise<string> {
-  const secretPath = fileEnvValue;
+  const secretPath = isAbsolute(fileEnvValue)
+    ? fileEnvValue
+    : resolve(process.env.INIT_CWD ?? process.cwd(), fileEnvValue);
   let fileSecret: string;
   try {
     fileSecret = await readFile(secretPath, "utf8");
@@ -196,19 +427,31 @@ export async function signerAccountLocks(
   ])];
 }
 
-function errorToLog(error: unknown): unknown {
+function errorToLog(error: unknown, secrets: SecretRedactionContext = {}): unknown {
   if (error instanceof Object && "stack" in error) {
-    const stack = error.stack ?? "";
+    const stack = redactSecretText(typeof error.stack === "string" ? error.stack : "", secrets);
     return {
       name: "name" in error ? error.name : undefined,
       message:
         "message" in error && typeof error.message === "string"
-          ? error.message
+          ? redactSecretText(error.message, secrets)
           : "Unknown error",
       txHash: "txHash" in error ? error.txHash : undefined,
       status: "status" in error ? error.status : undefined,
       stack,
     };
+  }
+
+  if (typeof error === "object" && error !== null) {
+    try {
+      return JSON.parse(redactSecretText(JSON.stringify(error, jsonLogReplacer), secrets)) as unknown;
+    } catch {
+      return { message: "Non-Error object (unserializable)" };
+    }
+  }
+
+  if (typeof error === "string") {
+    return redactSecretText(error, secrets);
   }
 
   return error ?? "Empty Error";
@@ -224,8 +467,9 @@ function shouldStopAfterError(error: unknown): boolean {
 export function handleLoopError(
   executionLog: Record<string, unknown>,
   error: unknown,
+  secrets: SecretRedactionContext = {},
 ): boolean {
-  executionLog.error = errorToLog(error);
+  executionLog.error = errorToLog(error, secrets);
   if (shouldStopAfterError(error)) {
     process.exitCode = STOP_EXIT_CODE;
     return true;

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -443,11 +443,7 @@ function errorToLog(error: unknown, secrets: SecretRedactionContext = {}): unkno
   }
 
   if (typeof error === "object" && error !== null) {
-    try {
-      return JSON.parse(redactSecretText(JSON.stringify(error, jsonLogReplacer), secrets)) as unknown;
-    } catch {
-      return { message: "Non-Error object (unserializable)" };
-    }
+    return sanitizeLogValue(error, secrets, new WeakSet<object>());
   }
 
   if (typeof error === "string") {
@@ -455,6 +451,46 @@ function errorToLog(error: unknown, secrets: SecretRedactionContext = {}): unkno
   }
 
   return error ?? "Empty Error";
+}
+
+function sanitizeLogValue(
+  value: unknown,
+  secrets: SecretRedactionContext,
+  seen: WeakSet<object>,
+): unknown {
+  if (typeof value === "string") {
+    return redactSecretText(value, secrets);
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry) => sanitizeLogValue(entry, secrets, seen));
+    }
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (isSensitiveLogKey(key)) {
+        continue;
+      }
+      sanitized[key] = sanitizeLogValue(entry, secrets, seen);
+    }
+    return sanitized;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function isSensitiveLogKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[-_]/gu, "");
+  return normalized === "privatekey" || normalized === "rpcurl";
 }
 
 function shouldStopAfterError(error: unknown): boolean {

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -130,17 +130,20 @@ export async function verifyChainPreflight(
   try {
     return assertChainPreflight(await readChainPreflight(client, chain));
   } catch (error) {
-    throw new Error(redactRpcUrlInError(error, client.url));
+    const secrets = { rpcUrl: client.url };
+    throw new Error(redactRpcUrlInError(error, secrets), {
+      cause: errorToLogValue(error, secrets, new WeakSet<object>()),
+    });
   }
 }
 
-function redactRpcUrlInError(error: unknown, rpcUrl: string): string {
+function redactRpcUrlInError(error: unknown, secrets: SecretRedactionContext): string {
   const message = typeof error === "string"
     ? error
     : error instanceof Error
       ? error.message
-      : stringifyErrorMessage(error);
-  return redactSecretText(message, { rpcUrl });
+      : stringifyErrorMessage(error, secrets);
+  return redactSecretText(message, secrets);
 }
 
 export function redactSecretText(text: string, secrets: SecretRedactionContext = {}): string {
@@ -155,12 +158,12 @@ export function redactSecretText(text: string, secrets: SecretRedactionContext =
   return redacted;
 }
 
-function stringifyErrorMessage(error: unknown): string {
+function stringifyErrorMessage(error: unknown, secrets: SecretRedactionContext): string {
   if (error === undefined || error === null) {
     return "Unknown error";
   }
   try {
-    return JSON.stringify(error, jsonLogReplacer);
+    return JSON.stringify(sanitizeLogValue(error, secrets, new WeakSet<object>()), jsonLogReplacer);
   } catch {
     return String(error);
   }
@@ -451,9 +454,21 @@ export async function signerAccountLocks(
 }
 
 function errorToLog(error: unknown, secrets: SecretRedactionContext = {}): unknown {
+  return errorToLogValue(error, secrets, new WeakSet<object>());
+}
+
+function errorToLogValue(
+  error: unknown,
+  secrets: SecretRedactionContext,
+  seen: WeakSet<object>,
+): unknown {
   if (error instanceof Object && "stack" in error) {
+    if (seen.has(error)) {
+      return "[Circular]";
+    }
+    seen.add(error);
     const stack = redactSecretText(typeof error.stack === "string" ? error.stack : "", secrets);
-    return {
+    const logged: Record<string, unknown> = {
       name: "name" in error ? error.name : undefined,
       message:
         "message" in error && typeof error.message === "string"
@@ -463,6 +478,14 @@ function errorToLog(error: unknown, secrets: SecretRedactionContext = {}): unkno
       status: "status" in error ? error.status : undefined,
       stack,
     };
+    try {
+      if ("cause" in error) {
+        logged.cause = errorToLogValue((error as { cause?: unknown }).cause, secrets, seen);
+      }
+      return logged;
+    } finally {
+      seen.delete(error);
+    }
   }
 
   if (typeof error === "object" && error !== null) {
@@ -490,6 +513,9 @@ function sanitizeLogValue(
   if (typeof value !== "object" || value === null) {
     return value;
   }
+  if (value instanceof Object && "stack" in value) {
+    return errorToLogValue(value, secrets, seen);
+  }
   if (seen.has(value)) {
     return "[Circular]";
   }
@@ -513,7 +539,9 @@ function sanitizeLogValue(
 
 function isSensitiveLogKey(key: string): boolean {
   const normalized = key.toLowerCase().replace(/[-_]/gu, "");
-  return normalized === "privatekey" || normalized === "rpcurl";
+  return ["privatekey", "rpcurl", "password", "token", "secret"].some(
+    (sensitiveKey) => normalized === sensitiveKey || normalized.endsWith(sensitiveKey),
+  );
 }
 
 function shouldStopAfterError(error: unknown): boolean {

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -132,7 +132,7 @@ export async function verifyChainPreflight(
   } catch (error) {
     const secrets = { rpcUrl: client.url };
     throw new Error(redactRpcUrlInError(error, secrets), {
-      cause: errorToLogValue(error, secrets, new WeakSet<object>()),
+      cause: errorToLogValue(error, secrets, new WeakSet()),
     });
   }
 }
@@ -163,9 +163,9 @@ function stringifyErrorMessage(error: unknown, secrets: SecretRedactionContext):
     return "Unknown error";
   }
   try {
-    return JSON.stringify(sanitizeLogValue(error, secrets, new WeakSet<object>()), jsonLogReplacer);
+    return JSON.stringify(sanitizeLogValue(error, secrets, new WeakSet()), jsonLogReplacer);
   } catch {
-    return String(error);
+    return "Unknown error";
   }
 }
 
@@ -454,7 +454,7 @@ export async function signerAccountLocks(
 }
 
 function errorToLog(error: unknown, secrets: SecretRedactionContext = {}): unknown {
-  return errorToLogValue(error, secrets, new WeakSet<object>());
+  return errorToLogValue(error, secrets, new WeakSet());
 }
 
 function errorToLogValue(
@@ -489,7 +489,7 @@ function errorToLogValue(
   }
 
   if (typeof error === "object" && error !== null) {
-    return sanitizeLogValue(error, secrets, new WeakSet<object>());
+    return sanitizeLogValue(error, secrets, new WeakSet());
   }
 
   if (typeof error === "string") {

--- a/packages/order/src/order.test.ts
+++ b/packages/order/src/order.test.ts
@@ -486,6 +486,37 @@ describe("OrderManager.addMatch", () => {
   });
 });
 
+describe("OrderManager.mint", () => {
+  it("creates an order output with the requested CKB value plus occupied capacity", () => {
+    const lock = script("11");
+    const udt = script("22");
+    const manager = new OrderManager(script("33"), [], udt);
+
+    const tx = manager.mint(
+      ccc.Transaction.default(),
+      lock,
+      dualInfo(),
+      { ckbValue: ccc.fixedPointFrom(123), udtValue: ccc.fixedPointFrom(456) },
+    );
+
+    expect(tx.outputs).toHaveLength(2);
+    const output = tx.getOutput(0);
+    if (output === undefined) {
+      throw new Error("Expected order output");
+    }
+    expect(OrderCell.mustFrom(ccc.Cell.from({
+      outPoint: { txHash: byte32FromByte("ef"), index: 0n },
+      cellOutput: output.cellOutput,
+      outputData: output.outputData,
+    })).ckbUnoccupied).toBe(ccc.fixedPointFrom(123));
+    expect(tx.outputs[0]?.capacity).toBeGreaterThan(ccc.fixedPointFrom(123));
+    expect(tx.outputs[0]?.lock.eq(manager.script)).toBe(true);
+    expect(tx.outputs[0]?.type?.eq(udt)).toBe(true);
+    expect(tx.outputs[1]?.lock.eq(lock)).toBe(true);
+    expect(tx.outputs[1]?.type?.eq(manager.script)).toBe(true);
+  });
+});
+
 describe("OrderCell.resolve", () => {
   it("prefers directional progress over a higher-value unprogressed candidate", () => {
     const master = {

--- a/packages/order/src/order.ts
+++ b/packages/order/src/order.ts
@@ -192,15 +192,18 @@ export class OrderManager implements ScriptDeps {
     tx.addCellDeps(this.cellDeps);
 
     // Append order cell to Outputs
-    const position = tx.addOutput(
+    const outputCount = tx.addOutput(
       {
         lock: this.script,
         type: this.udtScript,
       },
       data.toBytes(),
     );
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    tx.outputs[position]!.capacity += ckbValue;
+    const orderOutput = tx.outputs[outputCount - 1];
+    if (orderOutput === undefined) {
+      throw new Error("Failed to append order output");
+    }
+    orderOutput.capacity += ckbValue;
 
     // Append master cell to Outputs right after its order
     tx.addOutput({

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -30,6 +30,7 @@ import {
   IckbSdk,
   MAX_DIRECT_DEPOSITS,
   projectAccountAvailability,
+  projectConversionTransactionContext,
   sendAndWaitForCommit,
   TransactionConfirmationError,
   type SystemState,
@@ -536,6 +537,77 @@ describe("projectAccountAvailability", () => {
     expect(projection.ickbAvailable).toBe(7n);
     expect(projection.ickbPending).toBe(0n);
     expect(projection.ickbBalance).toBe(7n);
+  });
+});
+
+describe("projectConversionTransactionContext", () => {
+  it("projects conversion context from account state and collected-order policy", () => {
+    const readyWithdrawal = { owned: { isReady: true }, ckbValue: 11n, udtValue: 0n } as WithdrawalGroup;
+    const pendingWithdrawal = {
+      owned: { isReady: false, maturity: { toUnix: (): bigint => 5000n } },
+      ckbValue: 17n,
+      udtValue: 0n,
+    } as WithdrawalGroup;
+    const matchable = orderGroup({
+      ckbValue: 31n,
+      udtValue: 37n,
+      isDualRatio: false,
+      isMatchable: true,
+    });
+    Object.defineProperty(matchable.order, "maturity", { value: 7000n });
+    const receipt = { ckbValue: 41n, udtValue: 43n } as ReceiptCell;
+    const account = {
+      capacityCells: [{ cellOutput: { capacity: 3n } } as ccc.Cell],
+      nativeUdtCells: [],
+      nativeUdtCapacity: 0n,
+      nativeUdtBalance: 7n,
+      receipts: [receipt],
+      withdrawalGroups: [readyWithdrawal, pendingWithdrawal],
+    };
+    const currentSystem = system({ tip: headerLike(0n, { timestamp: 1000n }) });
+
+    const { projection, context } = projectConversionTransactionContext(
+      currentSystem,
+      account,
+      [matchable],
+      { collectedOrdersAvailable: true },
+    );
+
+    expect(projection.availableOrders).toEqual([matchable]);
+    expect(context).toEqual({
+      system: currentSystem,
+      receipts: [receipt],
+      readyWithdrawals: [readyWithdrawal],
+      availableOrders: [matchable],
+      ckbAvailable: projection.ckbAvailable,
+      ickbAvailable: projection.ickbAvailable,
+      estimatedMaturity: 5000n,
+    });
+  });
+
+  it("includes pending order maturity when collected orders are not budgeted", () => {
+    const matchable = orderGroup({
+      ckbValue: 31n,
+      udtValue: 37n,
+      isDualRatio: false,
+      isMatchable: true,
+    });
+    Object.defineProperty(matchable.order, "maturity", { value: 7000n });
+
+    const { context } = projectConversionTransactionContext(
+      system({ tip: headerLike(0n, { timestamp: 1000n }) }),
+      {
+        capacityCells: [],
+        nativeUdtCells: [],
+        nativeUdtCapacity: 0n,
+        nativeUdtBalance: 0n,
+        receipts: [],
+        withdrawalGroups: [],
+      },
+      [matchable],
+    );
+
+    expect(context.estimatedMaturity).toBe(7000n);
   });
 });
 
@@ -2651,7 +2723,7 @@ describe("IckbSdk.getL1State snapshot detection", () => {
     });
   });
 
-  it("fails closed when the chain tip changes during L1 state scanning", async () => {
+  it("fails closed when L1 state scanning crosses forward tip progress", async () => {
     const logic = script("22");
     const dao = script("33");
     const ownedOwner = script("44");
@@ -2681,7 +2753,69 @@ describe("IckbSdk.getL1State snapshot detection", () => {
     );
   });
 
-  it("fails closed when the chain tip changes during account state scanning", async () => {
+  it("fails closed when L1 state scanning crosses a reorg", async () => {
+    const logic = script("22");
+    const dao = script("33");
+    const ownedOwner = script("44");
+    const order = script("55");
+    const udt = script("66");
+    const firstTip = headerLike(1n, { hash: hash("01") });
+    const secondTip = headerLike(2n, { hash: hash("02") });
+    const replacedFirstTip = headerLike(1n, { hash: hash("03") });
+    const getTipHeader = vi
+      .fn<ccc.Client["getTipHeader"]>()
+      .mockResolvedValueOnce(firstTip)
+      .mockResolvedValueOnce(secondTip);
+    const sdk = new IckbSdk(
+      fakeIckbUdt(udt),
+      new OwnedOwnerManager(ownedOwner, [], new DaoManager(dao, [])),
+      new LogicManager(logic, [], new DaoManager(dao, [])),
+      new OrderManager(order, [], udt),
+      [],
+    );
+    const client = {
+      getTipHeader,
+      getHeaderByNumber: vi.fn<ccc.Client["getHeaderByNumber"]>().mockResolvedValue(replacedFirstTip),
+      getFeeRate: () => Promise.resolve(1n),
+      findCellsOnChain: () => none(),
+    } as unknown as ccc.Client;
+
+    await expect(sdk.getL1State(client, [])).rejects.toThrow(
+      "L1 state scan crossed chain tip",
+    );
+  });
+
+  it("fails closed when the chain tip is replaced during L1 state scanning", async () => {
+    const logic = script("22");
+    const dao = script("33");
+    const ownedOwner = script("44");
+    const order = script("55");
+    const udt = script("66");
+    const firstTip = headerLike(1n, { hash: hash("01") });
+    const replacementTip = headerLike(1n, { hash: hash("02") });
+    const getTipHeader = vi
+      .fn<ccc.Client["getTipHeader"]>()
+      .mockResolvedValueOnce(firstTip)
+      .mockResolvedValueOnce(replacementTip);
+    const sdk = new IckbSdk(
+      fakeIckbUdt(udt),
+      new OwnedOwnerManager(ownedOwner, [], new DaoManager(dao, [])),
+      new LogicManager(logic, [], new DaoManager(dao, [])),
+      new OrderManager(order, [], udt),
+      [],
+    );
+    const client = {
+      getTipHeader,
+      getFeeRate: () => Promise.resolve(1n),
+      findCellsOnChain: () => none(),
+    } as unknown as ccc.Client;
+
+    await expect(sdk.getL1State(client, [])).rejects.toThrow(
+      "L1 state scan crossed chain tip",
+    );
+  });
+
+  it("fails closed when account state scanning crosses forward tip progress", async () => {
     const accountLock = script("11");
     const logic = script("22");
     const dao = script("33");
@@ -2695,6 +2829,72 @@ describe("IckbSdk.getL1State snapshot detection", () => {
       .mockResolvedValueOnce(firstTip)
       .mockResolvedValueOnce(firstTip)
       .mockResolvedValueOnce(secondTip);
+    const sdk = new IckbSdk(
+      fakeIckbUdt(udt),
+      new OwnedOwnerManager(ownedOwner, [], new DaoManager(dao, [])),
+      new LogicManager(logic, [], new DaoManager(dao, [])),
+      new OrderManager(order, [], udt),
+      [],
+    );
+    const client = {
+      getTipHeader,
+      getFeeRate: () => Promise.resolve(1n),
+      findCellsOnChain: () => none(),
+    } as unknown as ccc.Client;
+
+    await expect(sdk.getL1AccountState(client, [accountLock])).rejects.toThrow(
+      "L1 state scan crossed chain tip",
+    );
+  });
+
+  it("fails closed when account state scanning crosses a reorg", async () => {
+    const accountLock = script("11");
+    const logic = script("22");
+    const dao = script("33");
+    const ownedOwner = script("44");
+    const order = script("55");
+    const udt = script("66");
+    const firstTip = headerLike(1n, { hash: hash("01") });
+    const secondTip = headerLike(2n, { hash: hash("02") });
+    const replacedFirstTip = headerLike(1n, { hash: hash("03") });
+    const getTipHeader = vi
+      .fn<ccc.Client["getTipHeader"]>()
+      .mockResolvedValueOnce(firstTip)
+      .mockResolvedValueOnce(firstTip)
+      .mockResolvedValueOnce(secondTip);
+    const sdk = new IckbSdk(
+      fakeIckbUdt(udt),
+      new OwnedOwnerManager(ownedOwner, [], new DaoManager(dao, [])),
+      new LogicManager(logic, [], new DaoManager(dao, [])),
+      new OrderManager(order, [], udt),
+      [],
+    );
+    const client = {
+      getTipHeader,
+      getHeaderByNumber: vi.fn<ccc.Client["getHeaderByNumber"]>().mockResolvedValue(replacedFirstTip),
+      getFeeRate: () => Promise.resolve(1n),
+      findCellsOnChain: () => none(),
+    } as unknown as ccc.Client;
+
+    await expect(sdk.getL1AccountState(client, [accountLock])).rejects.toThrow(
+      "L1 state scan crossed chain tip",
+    );
+  });
+
+  it("fails closed when the chain tip is replaced during account state scanning", async () => {
+    const accountLock = script("11");
+    const logic = script("22");
+    const dao = script("33");
+    const ownedOwner = script("44");
+    const order = script("55");
+    const udt = script("66");
+    const firstTip = headerLike(1n, { hash: hash("01") });
+    const replacementTip = headerLike(1n, { hash: hash("02") });
+    const getTipHeader = vi
+      .fn<ccc.Client["getTipHeader"]>()
+      .mockResolvedValueOnce(firstTip)
+      .mockResolvedValueOnce(firstTip)
+      .mockResolvedValueOnce(replacementTip);
     const sdk = new IckbSdk(
       fakeIckbUdt(udt),
       new OwnedOwnerManager(ownedOwner, [], new DaoManager(dao, [])),

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -1323,7 +1323,7 @@ export class IckbSdk {
     tip: ccc.ClientBlockHeader,
   ): Promise<void> {
     const currentTip = await client.getTipHeader();
-    if (currentTip.hash !== tip.hash) {
+    if (currentTip.number !== tip.number || currentTip.hash !== tip.hash) {
       throw new Error("L1 state scan crossed chain tip; retry with a fresh state");
     }
   }
@@ -1603,6 +1603,40 @@ export interface AccountAvailabilityProjection {
   pendingWithdrawals: WithdrawalGroup[];
   availableOrders: OrderGroup[];
   pendingOrders: OrderGroup[];
+}
+
+export interface ConversionTransactionContextProjection {
+  projection: AccountAvailabilityProjection;
+  context: ConversionTransactionContext;
+}
+
+export function projectConversionTransactionContext(
+  system: SystemState,
+  account: AccountState,
+  userOrders: OrderGroup[],
+  options?: Parameters<typeof projectAccountAvailability>[2],
+): ConversionTransactionContextProjection {
+  const projection = projectAccountAvailability(account, userOrders, options);
+  const estimatedMaturity = [
+    system.tip.timestamp,
+    ...projection.pendingWithdrawals.map((group) => group.owned.maturity.toUnix(system.tip)),
+    ...projection.pendingOrders
+      .map((group) => group.order.maturity)
+      .filter((maturity): maturity is bigint => maturity !== undefined),
+  ].reduce((best, maturity) => (best > maturity ? best : maturity));
+
+  return {
+    projection,
+    context: {
+      system,
+      receipts: account.receipts,
+      readyWithdrawals: projection.readyWithdrawals,
+      availableOrders: projection.availableOrders,
+      ckbAvailable: projection.ckbAvailable,
+      ickbAvailable: projection.ickbAvailable,
+      estimatedMaturity,
+    },
+  };
 }
 
 export function projectAccountAvailability(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,8 @@ catalogs:
       version: 24.12.2
 
 overrides:
+  brace-expansion@>=5.0.0 <5.0.6: 5.0.6
+  ws@>=8.0.0 <8.20.1: 8.20.1
   '@ckb-ccc/ccc': workspace:*
   '@ckb-ccc/core': workspace:*
   '@ckb-ccc/udt': workspace:*
@@ -395,10 +397,10 @@ importers:
         version: 6.16.0
       isomorphic-ws:
         specifier: ^5.0.0
-        version: 5.0.0(ws@8.20.0)
+        version: 5.0.0(ws@8.20.1)
       ws:
-        specifier: ^8.18.3
-        version: 8.20.0
+        specifier: 8.20.1
+        version: 8.20.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.34.0
@@ -2469,8 +2471,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   brorand@1.1.0:
@@ -3108,7 +3110,7 @@ packages:
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
     peerDependencies:
-      ws: '*'
+      ws: 8.20.1
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -4039,20 +4041,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5341,7 +5331,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5773,7 +5763,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.17.1
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6004,9 +5994,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@5.0.0(ws@8.20.0):
+  isomorphic-ws@5.0.0(ws@8.20.1):
     dependencies:
-      ws: 8.20.0
+      ws: 8.20.1
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -6207,7 +6197,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -6935,9 +6925,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.17.1: {}
-
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,9 @@ auditConfig:
     - CVE-2025-14505
 
 overrides:
+  # Security pins for vulnerable transitive ranges not yet lifted by upstreams.
+  "brace-expansion@>=5.0.0 <5.0.6": 5.0.6
+  "ws@>=8.0.0 <8.20.1": 8.20.1
   # Keep published manifests on `catalog:` while forcing the materialized
   # local CCC workspace to satisfy direct stack dependencies during installs.
   # Update this list alongside any new direct `@ckb-ccc/*` dependency.

--- a/scripts/ickb-generate-config.mjs
+++ b/scripts/ickb-generate-config.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const SECP256K1_ORDER = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
 const DEFAULT_RPC_URLS = {
   mainnet: "https://mainnet.ckb.dev/",
   testnet: "https://testnet.ckb.dev/",
@@ -183,11 +184,11 @@ function parsePositiveInteger(value, flag) {
   if (!/^[1-9][0-9]*$/u.test(value)) {
     throw new Error(`Invalid ${flag}: expected a positive integer`);
   }
-  const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed)) {
+  const parsed = BigInt(value);
+  if (parsed > MAX_SAFE_INTEGER) {
     throw new Error(`Invalid ${flag}: expected a safe integer`);
   }
-  return parsed;
+  return Number(parsed);
 }
 
 function parseRpcUrl(value) {

--- a/scripts/ickb-generate-config.mjs
+++ b/scripts/ickb-generate-config.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, realpath, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const SECP256K1_ORDER = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+const DEFAULT_RPC_URLS = {
+  mainnet: "https://mainnet.ckb.dev/",
+  testnet: "https://testnet.ckb.dev/",
+};
+
+export function parseArgs(argv) {
+  const args = {
+    chain: "testnet",
+    role: "bot",
+    sleepIntervalSeconds: 1,
+    maxIterations: 1,
+    force: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "-h" || arg === "--help") {
+      args.help = true;
+      continue;
+    }
+    if (arg === "--chain") {
+      args.chain = parseChain(valueAfter(argv, ++index, arg));
+      continue;
+    }
+    if (arg === "--role") {
+      args.role = parseRole(valueAfter(argv, ++index, arg));
+      continue;
+    }
+    if (arg === "--out") {
+      args.out = valueAfter(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--rpc-url") {
+      args.rpcUrl = parseRpcUrl(valueAfter(argv, ++index, arg));
+      continue;
+    }
+    if (arg === "--sleep-interval-seconds") {
+      args.sleepIntervalSeconds = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--max-iterations") {
+      args.maxIterations = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--no-max-iterations") {
+      args.maxIterations = undefined;
+      continue;
+    }
+    if (arg === "--force") {
+      args.force = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  args.rpcUrl ??= DEFAULT_RPC_URLS[args.chain];
+  args.out ??= `config/${args.role}-${args.chain}.json`;
+  return args;
+}
+
+export function usage() {
+  return [
+    "Usage: node scripts/ickb-generate-config.mjs [--chain testnet|mainnet] [--role <label>] [--out <ignored-json-config>] [--rpc-url <url>] [--sleep-interval-seconds <n>] [--max-iterations <n>|--no-max-iterations] [--force]",
+    "Defaults: --chain testnet --role bot --out config/<role>-<chain>.json --sleep-interval-seconds 1 --max-iterations 1",
+  ].join("\n");
+}
+
+export function generateSecp256k1PrivateKey(readRandomBytes = randomBytes) {
+  for (;;) {
+    const candidate = readRandomBytes(32);
+    if (candidate.length !== 32) {
+      throw new Error("Random byte source must return exactly 32 bytes");
+    }
+    const hex = candidate.toString("hex");
+    const value = BigInt(`0x${hex}`);
+    if (value > 0n && value < SECP256K1_ORDER) {
+      return `0x${hex}`;
+    }
+  }
+}
+
+export function buildRuntimeConfig({
+  chain,
+  privateKey,
+  rpcUrl,
+  sleepIntervalSeconds,
+  maxIterations,
+}) {
+  return {
+    chain,
+    privateKey,
+    rpcUrl,
+    sleepIntervalSeconds,
+    ...(maxIterations === undefined ? {} : { maxIterations }),
+  };
+}
+
+export async function runGenerateConfig({ argv, root = rootDir, dependencies = {} }) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    return { help: usage() };
+  }
+
+  const privateKey = generateSecp256k1PrivateKey(dependencies.randomBytes ?? randomBytes);
+  const config = buildRuntimeConfig({ ...args, privateKey });
+  const output = outputPath(root, args.out);
+  assertIgnoredPath(root, output.relativePath, dependencies.checkIgnored);
+  await makeSafeParentDir(output.absolutePath, root, dependencies);
+  await writeConfigFile(
+    output.absolutePath,
+    `${JSON.stringify(config)}\n`,
+    args.force,
+    dependencies,
+  );
+
+  return {
+    outputPath: output.relativePath,
+    role: args.role,
+    chain: args.chain,
+    redactedRpcUrl: redactRpcUrl(args.rpcUrl),
+    sleepIntervalSeconds: args.sleepIntervalSeconds,
+    maxIterations: args.maxIterations,
+    privateKey: "<written-to-config-file>",
+  };
+}
+
+export async function main(argv, io = {}) {
+  const stdout = io.stdout ?? process.stdout;
+  const stderr = io.stderr ?? process.stderr;
+  try {
+    const result = await runGenerateConfig({ argv });
+    if (result.help !== undefined) {
+      stdout.write(`${result.help}\n`);
+      return 0;
+    }
+    stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    stderr.write(`Config generation failed: ${message}\n${usage()}\n`);
+    return 1;
+  }
+}
+
+function valueAfter(argv, index, flag) {
+  const value = argv[index];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function parseChain(value) {
+  if (value !== "mainnet" && value !== "testnet") {
+    throw new Error("Invalid --chain: expected mainnet or testnet");
+  }
+  return value;
+}
+
+function parseRole(value) {
+  if (!/^[a-z][a-z0-9-]*$/u.test(value)) {
+    throw new Error("Invalid --role: expected lowercase letters, numbers, and hyphens");
+  }
+  return value;
+}
+
+function parsePositiveInteger(value, flag) {
+  if (!/^[1-9][0-9]*$/u.test(value)) {
+    throw new Error(`Invalid ${flag}: expected a positive integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`Invalid ${flag}: expected a safe integer`);
+  }
+  return parsed;
+}
+
+function parseRpcUrl(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (/\s/u.test(value[index] ?? "") || code < 0x20 || code === 0x7f) {
+      throw new Error("Invalid --rpc-url: expected http(s) URL");
+    }
+  }
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Invalid --rpc-url: expected http(s) URL");
+  }
+  return value;
+}
+
+function redactRpcUrl(rpcUrl) {
+  let url;
+  try {
+    url = new URL(rpcUrl);
+  } catch {
+    return "<invalid-url>";
+  }
+
+  if (url.username !== "" || url.password !== "") {
+    url.username = "redacted";
+    url.password = url.password === "" ? "" : "redacted";
+  }
+  if (url.pathname !== "" && url.pathname !== "/") {
+    url.pathname = "/...";
+  }
+  if (url.search !== "") {
+    const redactedParams = new URLSearchParams();
+    for (const [key] of url.searchParams) {
+      redactedParams.append(key, "redacted");
+    }
+    url.search = redactedParams.toString();
+  }
+
+  return url.toString();
+}
+
+function outputPath(root, out) {
+  const absolutePath = isAbsolute(out) ? out : resolve(root, out);
+  const relativePath = relative(root, absolutePath);
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    throw new Error("Output path must stay inside the repo");
+  }
+  return { absolutePath, relativePath };
+}
+
+async function writeConfigFile(path, text, force, dependencies) {
+  if (dependencies.writeFile !== undefined) {
+    await dependencies.writeFile(path, text, { flag: force ? "w" : "wx", mode: 0o600 });
+    return;
+  }
+  await assertNoSymlinkTarget(path, dependencies);
+  await assertRealParent(path, dependencies);
+  const flags = constants.O_WRONLY |
+    constants.O_CREAT |
+    constants.O_NOFOLLOW |
+    (force ? constants.O_TRUNC : constants.O_EXCL);
+  const handle = await (dependencies.open ?? open)(path, flags, 0o600);
+  try {
+    await handle.writeFile(text, "utf8");
+    await handle.chmod(0o600);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function makeSafeParentDir(path, root, dependencies) {
+  const parent = dirname(path);
+  await assertRealAncestor(root, dependencies);
+  const missing = [];
+  let current = parent;
+  for (;;) {
+    try {
+      await assertRealAncestor(current, dependencies);
+      break;
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        missing.push(current);
+        const next = dirname(current);
+        if (next === current) {
+          throw error;
+        }
+        current = next;
+        continue;
+      }
+      throw error;
+    }
+  }
+  for (const dir of missing.reverse()) {
+    await (dependencies.mkdir ?? mkdir)(dir, { mode: 0o700 });
+    await assertRealAncestor(dir, dependencies);
+  }
+}
+
+async function assertRealAncestor(path, dependencies) {
+  const stat = await (dependencies.lstat ?? lstat)(path);
+  if (stat.isSymbolicLink()) {
+    throw new Error("Refusing to write config through symlinked parent directory");
+  }
+}
+
+async function assertNoSymlinkTarget(path, dependencies) {
+  try {
+    const stat = await (dependencies.lstat ?? lstat)(path);
+    if (stat.isSymbolicLink()) {
+      throw new Error("Refusing to write through symlink config path");
+    }
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function assertRealParent(path, dependencies) {
+  const parent = dirname(path);
+  await assertRealAncestor(parent, dependencies);
+  const resolvedParent = await (dependencies.realpath ?? realpath)(parent);
+  if (resolvedParent !== parent) {
+    throw new Error("Refusing to write config through symlinked parent directory");
+  }
+}
+
+function assertIgnoredPath(root, relativePath, checkIgnored = defaultCheckIgnored) {
+  if (!checkIgnored(root, relativePath)) {
+    throw new Error(`Refusing to write non-ignored config path: ${relativePath}`);
+  }
+}
+
+function defaultCheckIgnored(root, relativePath) {
+  const result = spawnSync("git", ["-C", root, "check-ignore", "--", relativePath], {
+    encoding: "utf8",
+  });
+  return result.status === 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exit(await main(process.argv.slice(2)));
+}

--- a/scripts/ickb-generate-config.mjs
+++ b/scripts/ickb-generate-config.mjs
@@ -12,6 +12,7 @@ const DEFAULT_RPC_URLS = {
   mainnet: "https://mainnet.ckb.dev/",
   testnet: "https://testnet.ckb.dev/",
 };
+const ROLE_PATTERN = /^[a-z](?:[a-z0-9_-]{0,30}[a-z0-9])?$/u;
 
 export function parseArgs(argv) {
   const args = {
@@ -170,8 +171,10 @@ function parseChain(value) {
 }
 
 function parseRole(value) {
-  if (!/^[a-z][a-z0-9-]*$/u.test(value)) {
-    throw new Error("Invalid --role: expected lowercase letters, numbers, and hyphens");
+  if (!ROLE_PATTERN.test(value)) {
+    throw new Error(
+      "Invalid --role: expected 1-32 lowercase letters, numbers, hyphens, or underscores without trailing separators",
+    );
   }
   return value;
 }

--- a/scripts/ickb-generate-config.test.mjs
+++ b/scripts/ickb-generate-config.test.mjs
@@ -44,6 +44,10 @@ test("config generator parses defaults and explicit options", () => {
   assert.throws(() => parseArgs(["--role", "bot-"]), /Invalid --role/u);
   assert.throws(() => parseArgs(["--role", "bot_"]), /Invalid --role/u);
   assert.throws(() => parseArgs(["--role", `b${"o".repeat(31)}t`]), /Invalid --role/u);
+  assert.throws(
+    () => parseArgs(["--sleep-interval-seconds", "9007199254740993"]),
+    /safe integer/u,
+  );
   assert.match(usage(), /ickb-generate-config/u);
   assert.match(usage(), /--sleep-interval-seconds/u);
   assert.match(usage(), /--max-iterations/u);

--- a/scripts/ickb-generate-config.test.mjs
+++ b/scripts/ickb-generate-config.test.mjs
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict";
+import { constants } from "node:fs";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  buildRuntimeConfig,
+  generateSecp256k1PrivateKey,
+  parseArgs,
+  runGenerateConfig,
+  usage,
+} from "./ickb-generate-config.mjs";
+
+test("config generator parses defaults and explicit options", () => {
+  assert.deepEqual(parseArgs([]), {
+    chain: "testnet",
+    role: "bot",
+    sleepIntervalSeconds: 1,
+    maxIterations: 1,
+    force: false,
+    rpcUrl: "https://testnet.ckb.dev/",
+    out: "config/bot-testnet.json",
+  });
+  assert.deepEqual(parseArgs([
+    "--chain", "mainnet",
+    "--role", "tester",
+    "--out", "config/custom.json",
+    "--rpc-url", "https://user:pass@mainnet.example/path?token=secret",
+    "--sleep-interval-seconds", "10",
+    "--no-max-iterations",
+    "--force",
+  ]), {
+    chain: "mainnet",
+    role: "tester",
+    sleepIntervalSeconds: 10,
+    maxIterations: undefined,
+    force: true,
+    out: "config/custom.json",
+    rpcUrl: "https://user:pass@mainnet.example/path?token=secret",
+  });
+  assert.throws(() => parseArgs(["--chain", "devnet"]), /Invalid --chain/u);
+  assert.throws(() => parseArgs(["--role", "Bot"]), /Invalid --role/u);
+  assert.match(usage(), /ickb-generate-config/u);
+  assert.match(usage(), /--sleep-interval-seconds/u);
+  assert.match(usage(), /--max-iterations/u);
+  assert.match(usage(), /--no-max-iterations/u);
+  assert.match(usage(), /--force/u);
+});
+
+test("config generator rejects RPC URLs the runtime parser rejects", () => {
+  assert.throws(
+    () => parseArgs(["--rpc-url", "https://testnet.example/path with spaces"]),
+    /Invalid --rpc-url/u,
+  );
+  assert.throws(
+    () => parseArgs(["--rpc-url", "https://testnet.example/\t"]),
+    /Invalid --rpc-url/u,
+  );
+});
+
+test("config generator uses secp256k1 range rejection", () => {
+  const zero = Buffer.alloc(32);
+  const order = Buffer.from("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", "hex");
+  const aboveOrder = Buffer.from("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142", "hex");
+  const valid = Buffer.from("01".repeat(32), "hex");
+  const samples = [zero, order, aboveOrder, valid];
+
+  const privateKey = generateSecp256k1PrivateKey(() => samples.shift() ?? valid);
+
+  assert.equal(privateKey, `0x${"01".repeat(32)}`);
+});
+
+test("config generator refuses symlinked output paths", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ickb-generate-config-"));
+  try {
+    await mkdir(join(dir, "target"));
+    await symlink(join(dir, "target"), join(dir, "config"), "dir");
+
+    await assert.rejects(
+      () => runGenerateConfig({
+        argv: ["--out", "config/bot-testnet.json"],
+        root: dir,
+        dependencies: {
+          checkIgnored: () => true,
+          mkdir: async () => undefined,
+        },
+      }),
+      /symlinked parent directory/u,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("config generator opens output with no-follow and exclusive defaults", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ickb-generate-config-"));
+  const opened = [];
+  const dirs = new Set([dir]);
+  try {
+    await runGenerateConfig({
+      argv: ["--out", "config/bot-testnet.json"],
+      root: dir,
+      dependencies: {
+        randomBytes: () => Buffer.from("44".repeat(32), "hex"),
+        checkIgnored: () => true,
+        mkdir: async (path) => {
+          dirs.add(path);
+        },
+        lstat: async (path) => {
+          if (dirs.has(path)) {
+            return { isSymbolicLink: () => false };
+          }
+          const error = new Error("missing");
+          error.code = "ENOENT";
+          throw error;
+        },
+        realpath: async (path) => path,
+        open: async (path, flags, mode) => {
+          opened.push({ path, flags, mode });
+          return {
+            writeFile: async () => undefined,
+            chmod: async () => undefined,
+            close: async () => undefined,
+          };
+        },
+      },
+    });
+
+    assert.equal(opened.length, 1);
+    assert.equal(opened[0].flags & constants.O_NOFOLLOW, constants.O_NOFOLLOW);
+    assert.equal(opened[0].flags & constants.O_EXCL, constants.O_EXCL);
+    assert.equal(opened[0].mode, 0o600);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("config generator checks existing ancestors before creating missing parents", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ickb-generate-config-"));
+  const mkdirCalls = [];
+  const dirs = new Set([dir]);
+  try {
+    await runGenerateConfig({
+      argv: ["--out", "config/nested/bot-testnet.json"],
+      root: dir,
+      dependencies: {
+        randomBytes: () => Buffer.from("55".repeat(32), "hex"),
+        checkIgnored: () => true,
+        lstat: async (path) => {
+          if (dirs.has(path)) {
+            return { isSymbolicLink: () => false };
+          }
+          const error = new Error("missing");
+          error.code = "ENOENT";
+          throw error;
+        },
+        mkdir: async (path) => {
+          mkdirCalls.push(path);
+          dirs.add(path);
+        },
+        realpath: async (path) => path,
+        open: async () => ({
+          writeFile: async () => undefined,
+          chmod: async () => undefined,
+          close: async () => undefined,
+        }),
+      },
+    });
+
+    assert.deepEqual(mkdirCalls.map((path) => path.slice(dir.length + 1)), [
+      "config",
+      "config/nested",
+    ]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("config generator builds strict runtime config shape", () => {
+  assert.deepEqual(buildRuntimeConfig({
+    chain: "testnet",
+    privateKey: `0x${"11".repeat(32)}`,
+    rpcUrl: "https://testnet.ckb.dev/",
+    sleepIntervalSeconds: 1,
+    maxIterations: 1,
+  }), {
+    chain: "testnet",
+    privateKey: `0x${"11".repeat(32)}`,
+    rpcUrl: "https://testnet.ckb.dev/",
+    sleepIntervalSeconds: 1,
+    maxIterations: 1,
+  });
+  assert.deepEqual(buildRuntimeConfig({
+    chain: "mainnet",
+    privateKey: `0x${"22".repeat(32)}`,
+    rpcUrl: "https://mainnet.ckb.dev/",
+    sleepIntervalSeconds: 60,
+    maxIterations: undefined,
+  }), {
+    chain: "mainnet",
+    privateKey: `0x${"22".repeat(32)}`,
+    rpcUrl: "https://mainnet.ckb.dev/",
+    sleepIntervalSeconds: 60,
+  });
+});
+
+test("config generator writes only ignored configs and reports public metadata", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ickb-generate-config-"));
+  const written = [];
+  const dirs = new Set([dir]);
+  try {
+    const result = await runGenerateConfig({
+      argv: ["--out", "config/bot-testnet.json", "--rpc-url", "https://user:pass@testnet.example/path?token=secret"],
+      root: dir,
+      dependencies: {
+        randomBytes: () => Buffer.from("33".repeat(32), "hex"),
+        checkIgnored: (_root, relativePath) => relativePath.startsWith("config/"),
+        mkdir: async (path) => {
+          dirs.add(path);
+        },
+        lstat: async (path) => {
+          if (dirs.has(path)) {
+            return { isSymbolicLink: () => false };
+          }
+          const error = new Error("missing");
+          error.code = "ENOENT";
+          throw error;
+        },
+        realpath: async (path) => path,
+        writeFile: async (path, text, options) => {
+          written.push({ path, text, options });
+        },
+      },
+    });
+
+    assert.equal(written.length, 1);
+    assert.match(String(written[0].path), /config\/bot-testnet\.json$/u);
+    assert.deepEqual(written[0].options, { flag: "wx", mode: 0o600 });
+    assert.deepEqual(JSON.parse(written[0].text), {
+      chain: "testnet",
+      privateKey: `0x${"33".repeat(32)}`,
+      rpcUrl: "https://user:pass@testnet.example/path?token=secret",
+      sleepIntervalSeconds: 1,
+      maxIterations: 1,
+    });
+    assert.deepEqual(result, {
+      outputPath: "config/bot-testnet.json",
+      role: "bot",
+      chain: "testnet",
+      redactedRpcUrl: "https://redacted:redacted@testnet.example/...?token=redacted",
+      sleepIntervalSeconds: 1,
+      maxIterations: 1,
+      privateKey: "<written-to-config-file>",
+    });
+    assert.doesNotMatch(JSON.stringify(result), /0x33/u);
+    assert.doesNotMatch(JSON.stringify(result), /user:pass|token=secret/u);
+
+    await assert.rejects(
+      () => runGenerateConfig({
+        argv: ["--out", "not-ignored.json"],
+        root: dir,
+        dependencies: { checkIgnored: () => false },
+      }),
+      /Refusing to write non-ignored config path/u,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/ickb-generate-config.test.mjs
+++ b/scripts/ickb-generate-config.test.mjs
@@ -24,7 +24,7 @@ test("config generator parses defaults and explicit options", () => {
   });
   assert.deepEqual(parseArgs([
     "--chain", "mainnet",
-    "--role", "tester",
+    "--role", "tester_role",
     "--out", "config/custom.json",
     "--rpc-url", "https://user:pass@mainnet.example/path?token=secret",
     "--sleep-interval-seconds", "10",
@@ -32,7 +32,7 @@ test("config generator parses defaults and explicit options", () => {
     "--force",
   ]), {
     chain: "mainnet",
-    role: "tester",
+    role: "tester_role",
     sleepIntervalSeconds: 10,
     maxIterations: undefined,
     force: true,
@@ -41,6 +41,9 @@ test("config generator parses defaults and explicit options", () => {
   });
   assert.throws(() => parseArgs(["--chain", "devnet"]), /Invalid --chain/u);
   assert.throws(() => parseArgs(["--role", "Bot"]), /Invalid --role/u);
+  assert.throws(() => parseArgs(["--role", "bot-"]), /Invalid --role/u);
+  assert.throws(() => parseArgs(["--role", "bot_"]), /Invalid --role/u);
+  assert.throws(() => parseArgs(["--role", `b${"o".repeat(31)}t`]), /Invalid --role/u);
   assert.match(usage(), /ickb-generate-config/u);
   assert.match(usage(), /--sleep-interval-seconds/u);
   assert.match(usage(), /--max-iterations/u);

--- a/scripts/ickb-live-preflight.mjs
+++ b/scripts/ickb-live-preflight.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+
+export function parseArgs(argv) {
+  const args = { role: "preflight" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "-h" || arg === "--help") {
+      args.help = true;
+      continue;
+    }
+    if (arg === "--config") {
+      args.configPath = valueAfter(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--role") {
+      args.role = parseRole(valueAfter(argv, ++index, arg));
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!args.help && !args.configPath) {
+    throw new Error("Missing required --config <path>");
+  }
+
+  return args;
+}
+
+export function usage() {
+  return "Usage: node scripts/ickb-live-preflight.mjs --config <ignored-json-config> [--role <label>]";
+}
+
+export function publicScript(script) {
+  return {
+    codeHash: script.codeHash,
+    hashType: script.hashType,
+    args: script.args,
+  };
+}
+
+export function redactErrorMessage(error, secrets = {}) {
+  let message = error instanceof Error ? error.message : String(error ?? "Unknown error");
+  if (secrets.privateKey) {
+    message = message.split(secrets.privateKey).join("<redacted-private-key>");
+  }
+  message = secrets.redactSecretText?.(message, secrets) ?? message;
+  return message;
+}
+
+export async function runPreflight({ configPath, role, root = rootDir, dependencies }) {
+  const config = resolveConfigPath(root, configPath, dependencies?.checkIgnored);
+  await assertReadableConfigPath(root, config.absolutePath, dependencies);
+  const configText = await readFile(config.absolutePath, "utf8");
+  const { nodeUtils } = dependencies ?? await loadBuiltNodeUtils(root);
+  let runtimeConfig;
+  try {
+    runtimeConfig = nodeUtils.parseRuntimeConfig(configText, "LIVE_PREFLIGHT_CONFIG_FILE");
+  } catch {
+    throw new Error(
+      "Invalid live preflight config: expected exact JSON with chain, privateKey, rpcUrl, sleepIntervalSeconds, and optional maxIterations",
+    );
+  }
+
+  const {
+    ccc,
+    sdk: sdkModule,
+    core,
+  } = dependencies ?? await loadBuiltStack(root);
+
+  const secrets = {
+    privateKey: runtimeConfig.privateKey,
+    rpcUrl: runtimeConfig.rpcUrl,
+    redactedRpcUrl: nodeUtils.redactRpcUrl(runtimeConfig.rpcUrl),
+    redactSecretText: nodeUtils.redactSecretText,
+  };
+
+  try {
+    return await buildPreflightReport({
+      runtimeConfig,
+      role,
+      nodeUtils,
+      ccc,
+      sdk: sdkModule,
+      core,
+    });
+  } catch (error) {
+    throw new Error(redactErrorMessage(error, secrets));
+  }
+}
+
+export async function buildPreflightReport({
+  runtimeConfig,
+  role,
+  nodeUtils,
+  ccc,
+  sdk: sdkModule,
+  core,
+}) {
+  const client = nodeUtils.createPublicClient(runtimeConfig.chain, runtimeConfig.rpcUrl);
+  const chain = await nodeUtils.verifyChainPreflight(client, runtimeConfig.chain);
+  const signer = new ccc.SignerCkbPrivateKey(client, runtimeConfig.privateKey);
+  const recommended = await signer.getRecommendedAddressObj();
+  const primaryLock = recommended.script;
+  const accountLocks = await nodeUtils.signerAccountLocks(signer, primaryLock);
+  const stackConfig = sdkModule.getConfig(runtimeConfig.chain);
+  const ickb = sdkModule.IckbSdk.fromConfig(stackConfig);
+  const tip = await client.getTipHeader();
+  const [feeRate, account] = await Promise.all([
+    client.getFeeRate(),
+    ickb.getAccountState(client, accountLocks, tip),
+  ]);
+  const exchangeRatio = core.ickbExchangeRatio(tip);
+  const projection = sdkModule.projectAccountAvailability(account, [], {
+    collectedOrdersAvailable: true,
+  });
+  const totalCkb = projection.ckbAvailable + projection.ckbPending;
+  const totalEquivalentCkb = totalCkb + core.convert(false, projection.ickbAvailable, exchangeRatio);
+  const totalEquivalentIckb = core.convert(true, totalCkb, exchangeRatio) + projection.ickbAvailable;
+
+  return {
+    role,
+    chain: runtimeConfig.chain,
+    bounded: runtimeConfig.maxIterations !== undefined,
+    maxIterations: runtimeConfig.maxIterations,
+    sleepIntervalSeconds: runtimeConfig.sleepIntervalMs / 1000,
+    chainIdentity: chain,
+    key: {
+      recommendedAddress: recommended.toString(),
+      primaryLock: publicScript(primaryLock),
+      accountLocks: accountLocks.map(publicScript),
+    },
+    balances: {
+      CKB: {
+        available: nodeUtils.formatCkb(projection.ckbAvailable),
+        unavailable: nodeUtils.formatCkb(projection.ckbPending),
+        total: nodeUtils.formatCkb(totalCkb),
+      },
+      ICKB: {
+        available: nodeUtils.formatCkb(projection.ickbAvailable),
+      },
+      totalEquivalent: {
+        CKB: nodeUtils.formatCkb(totalEquivalentCkb),
+        ICKB: nodeUtils.formatCkb(totalEquivalentIckb),
+      },
+    },
+    inventory: {
+      userOrderCount: null,
+      userOrderScan: "skipped-global-scan",
+      receiptCount: account.receipts.length,
+      readyWithdrawalCount: projection.readyWithdrawals.length,
+      pendingWithdrawalCount: projection.pendingWithdrawals.length,
+    },
+    system: {
+      tip: {
+        hash: tip.hash,
+        number: tip.number,
+        timestamp: tip.timestamp,
+      },
+      feeRate,
+      exchangeRatio: {
+        ckbScale: exchangeRatio.ckbScale,
+        udtScale: exchangeRatio.udtScale,
+      },
+    },
+  };
+}
+
+export async function main(argv, io = {}) {
+  const stdout = io.stdout ?? process.stdout;
+  const stderr = io.stderr ?? process.stderr;
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (error) {
+    stderr.write(`${redactErrorMessage(error)}\n${usage()}\n`);
+    return 1;
+  }
+  if (args.help) {
+    stdout.write(`${usage()}\n`);
+    return 0;
+  }
+
+  try {
+    const report = await runPreflight(args);
+    const { jsonLogReplacer } = await import(
+      pathToFileURL(join(rootDir, "packages/node-utils/dist/index.js")).href
+    );
+    stdout.write(`${JSON.stringify(report, jsonLogReplacer, 2)}\n`);
+    return 0;
+  } catch (error) {
+    stderr.write(`Live preflight failed: ${redactErrorMessage(error)}\n`);
+    return 1;
+  }
+}
+
+async function loadBuiltNodeUtils(root) {
+  try {
+    const nodeUtils = await import(pathToFileURL(join(root, "packages/node-utils/dist/index.js")).href);
+    return { nodeUtils };
+  } catch (cause) {
+    throw new Error(
+      "Build @ickb/node-utils before running preflight, for example: pnpm --filter @ickb/node-utils build",
+      { cause },
+    );
+  }
+}
+
+async function loadBuiltStack(root) {
+  try {
+    const [sdk, core, cccModule] = await Promise.all([
+      import(pathToFileURL(join(root, "packages/sdk/dist/index.js")).href),
+      import(pathToFileURL(join(root, "packages/core/dist/index.js")).href),
+      import(pathToFileURL(join(root, "packages/node-utils/node_modules/@ckb-ccc/core/dist/index.js")).href),
+    ]);
+    return { sdk, core, ccc: cccModule.ccc };
+  } catch (cause) {
+    throw new Error(
+      "Build required packages before running preflight, for example: pnpm --filter @ickb/node-utils --filter @ickb/sdk --filter @ickb/core build",
+      { cause },
+    );
+  }
+}
+
+function valueAfter(argv, index, option) {
+  const value = argv[index];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function parseRole(value) {
+  if (!/^[a-z][a-z0-9_-]{0,31}$/u.test(value)) {
+    throw new Error("Invalid --role label");
+  }
+  return value;
+}
+
+function resolveConfigPath(root, configPath, checkIgnored = defaultCheckIgnored) {
+  const absolutePath = isAbsolute(configPath) ? configPath : resolve(root, configPath);
+  const relativePath = relative(root, absolutePath);
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    throw new Error("Config path must stay inside the repo");
+  }
+  if (!checkIgnored(root, relativePath)) {
+    throw new Error(`Refusing to read non-ignored config path: ${relativePath}`);
+  }
+  return { absolutePath, relativePath };
+}
+
+async function assertReadableConfigPath(root, configPath, dependencies = {}) {
+  await assertNoSymlinkedConfigAncestors(root, configPath, dependencies);
+  const stat = await (dependencies.lstat ?? lstat)(configPath);
+  if (stat.isSymbolicLink()) {
+    throw new Error("Refusing to read symlink config path");
+  }
+
+  const resolvedPath = await (dependencies.realpath ?? realpath)(configPath);
+  const relativePath = relative(root, resolvedPath);
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    throw new Error("Config path must stay inside the repo");
+  }
+}
+
+async function assertNoSymlinkedConfigAncestors(root, configPath, dependencies) {
+  const lstatFn = dependencies.lstat ?? lstat;
+  const parts = relative(root, configPath).split("/").filter((part) => part !== "");
+  let current = root;
+  for (const part of parts.slice(0, -1)) {
+    current = join(current, part);
+    const stat = await lstatFn(current);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to read config through symlinked path: ${relative(root, current)}`);
+    }
+  }
+}
+
+function defaultCheckIgnored(root, relativePath) {
+  const result = spawnSync("git", ["-C", root, "check-ignore", "--", relativePath], {
+    encoding: "utf8",
+  });
+  return result.status === 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exit(await main(process.argv.slice(2)));
+}

--- a/scripts/ickb-live-preflight.mjs
+++ b/scripts/ickb-live-preflight.mjs
@@ -65,9 +65,10 @@ export async function runPreflight({ configPath, role, root = rootDir, dependenc
   let runtimeConfig;
   try {
     runtimeConfig = nodeUtils.parseRuntimeConfig(configText, "LIVE_PREFLIGHT_CONFIG_FILE");
-  } catch {
+  } catch (cause) {
     throw new Error(
       "Invalid live preflight config: expected exact JSON with chain, privateKey, rpcUrl, sleepIntervalSeconds, and optional maxIterations",
+      { cause },
     );
   }
 

--- a/scripts/ickb-live-preflight.mjs
+++ b/scripts/ickb-live-preflight.mjs
@@ -219,7 +219,7 @@ async function loadBuiltStack(root) {
     const [sdk, core, cccModule] = await Promise.all([
       import(pathToFileURL(join(root, "packages/sdk/dist/index.js")).href),
       import(pathToFileURL(join(root, "packages/core/dist/index.js")).href),
-      import(pathToFileURL(join(root, "packages/node-utils/node_modules/@ckb-ccc/core/dist/index.js")).href),
+      import(pathToFileURL(join(root, "forks/ccc/repo/packages/core/dist/index.js")).href),
     ]);
     return { sdk, core, ccc: cccModule.ccc };
   } catch (cause) {

--- a/scripts/ickb-live-preflight.mjs
+++ b/scripts/ickb-live-preflight.mjs
@@ -5,6 +5,7 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const ROLE_PATTERN = /^[a-z](?:[a-z0-9_-]{0,30}[a-z0-9])?$/u;
 
 export function parseArgs(argv) {
   const args = { role: "preflight" };
@@ -239,8 +240,10 @@ function valueAfter(argv, index, option) {
 }
 
 function parseRole(value) {
-  if (!/^[a-z][a-z0-9_-]{0,31}$/u.test(value)) {
-    throw new Error("Invalid --role label");
+  if (!ROLE_PATTERN.test(value)) {
+    throw new Error(
+      "Invalid --role: expected 1-32 lowercase letters, numbers, hyphens, or underscores without trailing separators",
+    );
   }
   return value;
 }

--- a/scripts/ickb-live-preflight.test.mjs
+++ b/scripts/ickb-live-preflight.test.mjs
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  parseArgs,
+  publicScript,
+  redactErrorMessage,
+  runPreflight,
+  usage,
+} from "./ickb-live-preflight.mjs";
+
+test("preflight CLI parses config and role arguments", () => {
+  assert.deepEqual(parseArgs(["--config", "config/bot-testnet.json", "--role", "bot"]), {
+    configPath: "config/bot-testnet.json",
+    role: "bot",
+  });
+  assert.deepEqual(parseArgs(["--", "--help"]), { role: "preflight", help: true });
+  assert.deepEqual(parseArgs(["--help"]), { role: "preflight", help: true });
+  assert.throws(() => parseArgs([]), /Missing required --config/u);
+  assert.throws(() => parseArgs(["--config", "x", "--role", "Bot!"]), /Invalid --role/u);
+  assert.match(usage(), /--config <ignored-json-config>/u);
+});
+
+test("preflight CLI exposes public script shape only", () => {
+  assert.deepEqual(publicScript({
+    codeHash: "0x11",
+    hashType: "type",
+    args: "0x22",
+    extra: "ignored",
+  }), {
+    codeHash: "0x11",
+    hashType: "type",
+    args: "0x22",
+  });
+});
+
+test("preflight CLI redacts private key and RPC URL in errors", () => {
+  const privateKey = `0x${"11".repeat(32)}`;
+  const rpcUrl = "https://user:pass@testnet.example/path?token=secret";
+  const redacted = "https://redacted:redacted@testnet.example/...?token=redacted";
+  const error = new Error(`failed with ${privateKey} using ${rpcUrl} user pass secret`);
+
+  const message = redactErrorMessage(error, {
+    privateKey,
+    rpcUrl,
+    redactedRpcUrl: redacted,
+    redactSecretText,
+  });
+
+  assert.equal(
+    message,
+    `failed with <redacted-private-key> using ${redacted} ` +
+      "<redacted-rpc-username> <redacted-rpc-password> <redacted-rpc-query>",
+  );
+  assert.doesNotMatch(message, /0x11/u);
+  assert.doesNotMatch(message, /secret/u);
+  assert.doesNotMatch(message, /\buser\b|\bpass\b/u);
+});
+
+test("preflight run reports public evidence for a generated unfunded key", async () => {
+  const privateKey = `0x${randomBytes(32).toString("hex")}`;
+  const rawRpcUrl = "https://user:pass@testnet.example/path?token=secret";
+  const dir = await mkdtemp(join(tmpdir(), "ickb-live-preflight-"));
+  try {
+    const configPath = join(dir, "config.json");
+    await writeFile(configPath, JSON.stringify({
+      chain: "testnet",
+      privateKey,
+      rpcUrl: rawRpcUrl,
+      sleepIntervalSeconds: 1,
+      maxIterations: 1,
+    }));
+
+    const report = await runPreflight({
+      configPath,
+      role: "bot",
+      root: dir,
+      dependencies: { ...mockDependencies(), checkIgnored: () => true },
+    });
+    const json = JSON.stringify(report, bigintReplacer);
+
+    assert.equal(report.role, "bot");
+    assert.equal(report.chain, "testnet");
+    assert.equal(report.bounded, true);
+    assert.equal(report.maxIterations, 1);
+    assert.equal(report.chainIdentity.redactedRpcUrl, "https://redacted:redacted@testnet.example/...?token=redacted");
+    assert.equal(report.chainIdentity.matches.genesisHash, true);
+    assert.equal(report.key.recommendedAddress, "ckt1generatedoffline");
+    assert.deepEqual(report.key.primaryLock, {
+      codeHash: "0x" + "11".repeat(32),
+      hashType: "type",
+      args: "0x" + "22".repeat(20),
+    });
+    assert.equal(report.balances.CKB.total, "0");
+    assert.equal(report.inventory.userOrderCount, null);
+    assert.equal(report.inventory.userOrderScan, "skipped-global-scan");
+    assert.doesNotMatch(json, new RegExp(privateKey, "u"));
+    assert.doesNotMatch(json, /secret/u);
+    assert.doesNotMatch(json, /user:pass/u);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("preflight refuses non-ignored and out-of-repo config paths", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ickb-live-preflight-"));
+  try {
+    const configPath = join(dir, "config.json");
+    await writeFile(configPath, JSON.stringify({}));
+
+    await assert.rejects(
+      () => runPreflight({
+        configPath,
+        role: "bot",
+        root: dir,
+        dependencies: { checkIgnored: () => false },
+      }),
+      /Refusing to read non-ignored config path: config\.json/u,
+    );
+    await assert.rejects(
+      () => runPreflight({
+        configPath: join(dir, "..", "config.json"),
+        role: "bot",
+        root: dir,
+        dependencies: { checkIgnored: () => true },
+      }),
+      /Config path must stay inside the repo/u,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("preflight refuses symlink config paths", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ickb-live-preflight-"));
+  try {
+    await writeFile(join(dir, "target.json"), JSON.stringify({}));
+    const configPath = join(dir, "config.json");
+    await symlink(join(dir, "target.json"), configPath);
+
+    await assert.rejects(
+      () => runPreflight({
+        configPath,
+        role: "bot",
+        root: dir,
+        dependencies: { checkIgnored: () => true },
+      }),
+      /Refusing to read symlink config path/u,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("preflight refuses symlinked config parent paths", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ickb-live-preflight-"));
+  try {
+    await writeFile(join(dir, "target.json"), JSON.stringify({}));
+    await symlink(dir, join(dir, "config"), "dir");
+
+    await assert.rejects(
+      () => runPreflight({
+        configPath: join(dir, "config", "target.json"),
+        role: "bot",
+        root: dir,
+        dependencies: { checkIgnored: () => true },
+      }),
+      /Refusing to read config through symlinked path: config/u,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+function mockDependencies() {
+  const expectedGenesis = "0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606";
+  const nodeUtils = {
+    parseRuntimeConfig: (text) => {
+      const parsed = JSON.parse(text);
+      return {
+        ...parsed,
+        sleepIntervalMs: parsed.sleepIntervalSeconds * 1000,
+      };
+    },
+    redactRpcUrl: () => "https://redacted:redacted@testnet.example/...?token=redacted",
+    redactSecretText,
+    createPublicClient: () => ({
+      url: "mock",
+      addressPrefix: "ckt",
+      getTipHeader: async () => ({ hash: "0x" + "44".repeat(32), number: 3n, timestamp: 4n }),
+      getFeeRate: async () => 1000n,
+    }),
+    verifyChainPreflight: async () => ({
+      chain: "testnet",
+      redactedRpcUrl: "https://redacted:redacted@testnet.example/...?token=redacted",
+      expected: { genesisHash: expectedGenesis, addressPrefix: "ckt" },
+      observed: {
+        genesisHash: expectedGenesis,
+        addressPrefix: "ckt",
+        tip: { hash: "0x" + "33".repeat(32), number: 1n, timestamp: 2n },
+      },
+      matches: { genesisHash: true, addressPrefix: true },
+    }),
+    signerAccountLocks: async (_signer, primaryLock) => [primaryLock],
+    formatCkb: (value) => value.toString(),
+  };
+  const primaryLock = {
+    codeHash: "0x" + "11".repeat(32),
+    hashType: "type",
+    args: "0x" + "22".repeat(20),
+  };
+  return {
+    nodeUtils,
+    ccc: {
+      SignerCkbPrivateKey: class {
+        async getRecommendedAddressObj() {
+          return {
+            script: primaryLock,
+            toString: () => "ckt1generatedoffline",
+          };
+        }
+      },
+    },
+    sdk: {
+      getConfig: () => ({}),
+      IckbSdk: {
+        fromConfig: () => ({
+          getAccountState: async () => ({ receipts: [], withdrawalGroups: [] }),
+        }),
+      },
+      projectAccountAvailability: () => ({
+        ckbAvailable: 0n,
+        ckbPending: 0n,
+        ickbAvailable: 0n,
+        readyWithdrawals: [],
+        pendingWithdrawals: [],
+      }),
+    },
+    core: {
+      ickbExchangeRatio: () => ({ ckbScale: 1n, udtScale: 1n }),
+      convert: (_toIckb, value) => value,
+    },
+  };
+}
+
+function redactSecretText(text, secrets = {}) {
+  let redacted = text;
+  if (secrets.privateKey) {
+    redacted = redacted.split(secrets.privateKey).join("<redacted-private-key>");
+  }
+  if (secrets.rpcUrl) {
+    redacted = redacted
+      .split(secrets.rpcUrl).join(secrets.redactedRpcUrl)
+      .split("user").join("<redacted-rpc-username>")
+      .split("pass").join("<redacted-rpc-password>")
+      .split("secret").join("<redacted-rpc-query>");
+  }
+  return redacted;
+}
+
+function bigintReplacer(_key, value) {
+  return typeof value === "bigint" ? value.toString() : value;
+}

--- a/scripts/ickb-live-preflight.test.mjs
+++ b/scripts/ickb-live-preflight.test.mjs
@@ -13,14 +13,17 @@ import {
 } from "./ickb-live-preflight.mjs";
 
 test("preflight CLI parses config and role arguments", () => {
-  assert.deepEqual(parseArgs(["--config", "config/bot-testnet.json", "--role", "bot"]), {
+  assert.deepEqual(parseArgs(["--config", "config/bot-testnet.json", "--role", "bot_live"]), {
     configPath: "config/bot-testnet.json",
-    role: "bot",
+    role: "bot_live",
   });
   assert.deepEqual(parseArgs(["--", "--help"]), { role: "preflight", help: true });
   assert.deepEqual(parseArgs(["--help"]), { role: "preflight", help: true });
   assert.throws(() => parseArgs([]), /Missing required --config/u);
   assert.throws(() => parseArgs(["--config", "x", "--role", "Bot!"]), /Invalid --role/u);
+  assert.throws(() => parseArgs(["--config", "x", "--role", "bot-"]), /Invalid --role/u);
+  assert.throws(() => parseArgs(["--config", "x", "--role", "bot_"]), /Invalid --role/u);
+  assert.throws(() => parseArgs(["--config", "x", "--role", `b${"o".repeat(31)}t`]), /Invalid --role/u);
   assert.match(usage(), /--config <ignored-json-config>/u);
 });
 

--- a/scripts/ickb-live-preflight.test.mjs
+++ b/scripts/ickb-live-preflight.test.mjs
@@ -108,6 +108,48 @@ test("preflight run reports public evidence for a generated unfunded key", async
   }
 });
 
+test("preflight preserves parse failure cause without leaking config contents", async () => {
+  const privateKey = `0x${"11".repeat(32)}`;
+  const dir = await mkdtemp(join(tmpdir(), "ickb-live-preflight-"));
+  try {
+    const configPath = join(dir, "config.json");
+    await writeFile(configPath, JSON.stringify({
+      chain: "testnet",
+      privateKey,
+      rpcUrl: "not-a-url",
+      sleepIntervalSeconds: 1,
+      maxIterations: 1,
+    }));
+
+    const parseError = new Error("Invalid env LIVE_PREFLIGHT_CONFIG_FILE");
+
+    await assert.rejects(
+      () => runPreflight({
+        configPath,
+        role: "bot",
+        root: dir,
+        dependencies: {
+          checkIgnored: () => true,
+          nodeUtils: {
+            parseRuntimeConfig: () => {
+              throw parseError;
+            },
+          },
+        },
+      }),
+      (error) => {
+        assert(error instanceof Error);
+        assert.match(error.message, /Invalid live preflight config/u);
+        assert.doesNotMatch(error.message, new RegExp(privateKey, "u"));
+        assert.equal(error.cause, parseError);
+        return true;
+      },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("preflight refuses non-ignored and out-of-repo config paths", async () => {
   const dir = await mkdtemp(join(tmpdir(), "ickb-live-preflight-"));
   try {


### PR DESCRIPTION
## Why
Core runtime entry points need fail-closed chain identity checks, secret-safe config/preflight tooling, and transaction planning that does not treat reserved plain CKB as spendable.

## Changes
- Pin vulnerable transitive brace-expansion and ws ranges.
- Add runtime config generation and preflight scripts with ignored-path, symlink, secp256k1 key, chain identity, and secret-redaction safeguards.
- Fail closed when SDK scan tips drift and guard order mint output mutation.
- Reuse conversion projection in the interface and reserve plain CKB before planning CKB conversions.