### PR TITLE
feat(node-utils): allow default runtime RPC

### DIFF
--- a/apps/bot/src/index.test.ts
+++ b/apps/bot/src/index.test.ts
@@ -215,6 +215,7 @@ describe("readBotRuntimeConfig", () => {
         rpcUrl: "http://127.0.0.1:8114/",
         sleepIntervalMs: 60000,
         maxIterations: 1,
+        maxRetryableAttempts: undefined,
       });
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/apps/tester/src/index.test.ts
+++ b/apps/tester/src/index.test.ts
@@ -45,6 +45,7 @@ describe("readTesterRuntimeConfig", () => {
         rpcUrl: "http://127.0.0.1:8114/",
         sleepIntervalMs: 10000,
         maxIterations: 1,
+        maxRetryableAttempts: undefined,
       });
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -42,10 +42,11 @@ describe("node utilities", () => {
   it("parses positive sleep intervals as milliseconds", () => {
     expect(parseSleepInterval(1, "BOT_CONFIG_FILE")).toBe(1000);
     expect(parseSleepInterval(2.5, "BOT_CONFIG_FILE")).toBe(2500);
+    expect(parseSleepInterval(1073741, "BOT_CONFIG_FILE")).toBe(1073741000);
   });
 
   it("rejects missing and sub-second sleep intervals", () => {
-    for (const value of [undefined, Number.NaN, Infinity, 0, 0.5]) {
+    for (const value of [undefined, Number.NaN, Infinity, 0, 0.5, 1073741.824, 9007199254741]) {
       expect(() => parseSleepInterval(value, "BOT_CONFIG_FILE")).toThrow(
         "Invalid env BOT_CONFIG_FILE",
       );
@@ -116,6 +117,7 @@ describe("node utilities", () => {
       rpcUrl: "https://rpc.example/path?token=abc",
       sleepIntervalMs: 60000,
       maxIterations: 2,
+      maxRetryableAttempts: undefined,
     });
     expect(parseRuntimeConfig(JSON.stringify({
       chain: "mainnet",
@@ -128,6 +130,32 @@ describe("node utilities", () => {
       rpcUrl: "https://mainnet.example/",
       sleepIntervalMs: 1000,
       maxIterations: undefined,
+      maxRetryableAttempts: undefined,
+    });
+    expect(parseRuntimeConfig(JSON.stringify({
+      chain: "testnet",
+      privateKey,
+      sleepIntervalSeconds: 5,
+    }), "BOT_CONFIG_FILE")).toEqual({
+      chain: "testnet",
+      privateKey,
+      rpcUrl: undefined,
+      sleepIntervalMs: 5000,
+      maxIterations: undefined,
+      maxRetryableAttempts: undefined,
+    });
+    expect(parseRuntimeConfig(JSON.stringify({
+      chain: "testnet",
+      privateKey,
+      sleepIntervalSeconds: 5,
+      maxRetryableAttempts: 3,
+    }), "BOT_CONFIG_FILE")).toEqual({
+      chain: "testnet",
+      privateKey,
+      rpcUrl: undefined,
+      sleepIntervalMs: 5000,
+      maxIterations: undefined,
+      maxRetryableAttempts: 3,
     });
   });
 
@@ -139,13 +167,16 @@ describe("node utilities", () => {
       JSON.stringify({ chain: "devnet", privateKey, sleepIntervalSeconds: 60 }),
       JSON.stringify({ chain: privateKey, privateKey, rpcUrl: "https://rpc.example/", sleepIntervalSeconds: 60 }),
       JSON.stringify({ chain: "testnet", privateKey, sleepIntervalSeconds: 60, extra: true }),
-      JSON.stringify({ chain: "testnet", privateKey, sleepIntervalSeconds: 60 }),
       JSON.stringify({ chain: "testnet", privateKey: `${privateKey}\n`, sleepIntervalSeconds: 60 }),
+      JSON.stringify({ chain: "testnet", privateKey, rpcUrl: "", sleepIntervalSeconds: 60 }),
       JSON.stringify({ chain: "testnet", privateKey, rpcUrl: "file:///tmp/socket", sleepIntervalSeconds: 60 }),
       JSON.stringify({ chain: "testnet", privateKey, rpcUrl: "https://rpc.example/ bad", sleepIntervalSeconds: 60 }),
+      JSON.stringify({ chain: "testnet", privateKey, rpcUrl: 8114, sleepIntervalSeconds: 60 }),
       JSON.stringify({ chain: "testnet", privateKey, sleepIntervalSeconds: "60" }),
       JSON.stringify({ chain: "testnet", privateKey, sleepIntervalSeconds: 0 }),
       JSON.stringify({ chain: "testnet", privateKey, sleepIntervalSeconds: 60, maxIterations: "1" }),
+      JSON.stringify({ chain: "testnet", privateKey, sleepIntervalSeconds: 60, maxRetryableAttempts: "1" }),
+      JSON.stringify({ chain: "testnet", privateKey, sleepIntervalSeconds: 60, maxRetryableAttempts: 0 }),
     ];
 
     for (const value of invalidValues) {
@@ -175,6 +206,7 @@ describe("node utilities", () => {
         rpcUrl: "http://127.0.0.1:8114/",
         sleepIntervalMs: 60000,
         maxIterations: undefined,
+        maxRetryableAttempts: undefined,
       });
       await expect(readRuntimeConfigEnv(undefined, "BOT_CONFIG_FILE")).rejects.toThrow(
         "Empty env BOT_CONFIG_FILE",
@@ -220,6 +252,7 @@ describe("node utilities", () => {
   it("creates network-specific public clients and forwards custom RPC URLs", () => {
     const mainnet = createPublicClient("mainnet", "https://mainnet.example");
     const testnet = createPublicClient("testnet", undefined);
+    const defaultTestnet = new ccc.ClientPublicTestnet();
 
     expect(mainnet).toBeInstanceOf(ccc.ClientPublicMainnet);
     expect(testnet).toBeInstanceOf(ccc.ClientPublicTestnet);
@@ -228,6 +261,7 @@ describe("node utilities", () => {
     expect((mainnet as ccc.ClientPublicMainnet).url).toBe(
       "https://mainnet.example",
     );
+    expect((testnet as ccc.ClientPublicTestnet).url).toBe(defaultTestnet.url);
   });
 
   it("pins official CKB chain identities for preflight checks", () => {

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   handleLoopError,
   logExecution,
   parseMaxIterations,
+  parseMaxRetryableAttempts,
   parseRuntimeConfig,
   parsePrivateKey,
   readRuntimeConfigEnv,
@@ -64,6 +65,11 @@ describe("node utilities", () => {
       "Invalid env BOT_CONFIG_FILE",
     );
     expect(() => parseMaxIterations(1.5, "BOT_CONFIG_FILE")).toThrow(
+      "Invalid env BOT_CONFIG_FILE",
+    );
+    expect(parseMaxRetryableAttempts(undefined, "BOT_CONFIG_FILE")).toBeUndefined();
+    expect(parseMaxRetryableAttempts(3, "BOT_CONFIG_FILE")).toBe(3);
+    expect(() => parseMaxRetryableAttempts(0, "BOT_CONFIG_FILE")).toThrow(
       "Invalid env BOT_CONFIG_FILE",
     );
   });

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -45,8 +45,8 @@ describe("node utilities", () => {
     expect(parseSleepInterval(1073741, "BOT_CONFIG_FILE")).toBe(1073741000);
   });
 
-  it("rejects missing and sub-second sleep intervals", () => {
-    for (const value of [undefined, Number.NaN, Infinity, 0, 0.5, 1073741.824, 9007199254741]) {
+  it("rejects invalid sleep intervals", () => {
+    for (const value of [undefined, Number.NaN, Infinity, -1, 0, 0.5, 1073741.824, 9007199254741]) {
       expect(() => parseSleepInterval(value, "BOT_CONFIG_FILE")).toThrow(
         "Invalid env BOT_CONFIG_FILE",
       );

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -7,7 +7,8 @@ import { setTimeout } from "node:timers";
 
 const CKB = 100000000n;
 const SECP256K1_ORDER = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
+// Jitter can double the configured interval; keep the result within Node's timer limit.
+const MAX_SAFE_SLEEP_INTERVAL_MS = 1_073_741_823;
 
 export const STOP_EXIT_CODE = 2;
 
@@ -283,7 +284,7 @@ export function parseSleepInterval(
   }
 
   const intervalMs = intervalSeconds * 1000;
-  if (!Number.isSafeInteger(intervalMs) || intervalMs > MAX_TIMER_DELAY_MS / 2) {
+  if (!Number.isSafeInteger(intervalMs) || intervalMs > MAX_SAFE_SLEEP_INTERVAL_MS) {
     throw new Error("Invalid env " + envName);
   }
 
@@ -339,6 +340,13 @@ export function parseRpcUrl(rpcUrl: string, envName: string): string {
 }
 
 export function parseMaxIterations(
+  value: number | undefined,
+  envName: string,
+): number | undefined {
+  return parsePositiveSafeInteger(value, envName);
+}
+
+function parsePositiveSafeInteger(
   value: number | undefined,
   envName: string,
 ): number | undefined {
@@ -411,8 +419,8 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
     privateKey: parsePrivateKey(record.privateKey, envName),
     rpcUrl: record.rpcUrl !== undefined ? parseRpcUrl(record.rpcUrl, envName) : undefined,
     sleepIntervalMs: parseSleepInterval(record.sleepIntervalSeconds, envName),
-    maxIterations: parseMaxIterations(record.maxIterations, envName),
-    maxRetryableAttempts: parseMaxIterations(record.maxRetryableAttempts, envName),
+    maxIterations: parsePositiveSafeInteger(record.maxIterations, envName),
+    maxRetryableAttempts: parsePositiveSafeInteger(record.maxRetryableAttempts, envName),
   };
 }
 

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -7,6 +7,7 @@ import { setTimeout } from "node:timers";
 
 const CKB = 100000000n;
 const SECP256K1_ORDER = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 export const STOP_EXIT_CODE = 2;
 
@@ -281,7 +282,12 @@ export function parseSleepInterval(
     throw new Error("Invalid env " + envName);
   }
 
-  return intervalSeconds * 1000;
+  const intervalMs = intervalSeconds * 1000;
+  if (!Number.isSafeInteger(intervalMs) || intervalMs > Math.floor(MAX_TIMER_DELAY_MS / 2)) {
+    throw new Error("Invalid env " + envName);
+  }
+
+  return intervalMs;
 }
 
 export function parsePrivateKey(privateKey: string, envName: string): `0x${string}` {
@@ -298,9 +304,10 @@ export function parsePrivateKey(privateKey: string, envName: string): `0x${strin
 export type RuntimeConfig = {
   chain: SupportedChain;
   privateKey: `0x${string}`;
-  rpcUrl: string;
+  rpcUrl?: string;
   sleepIntervalMs: number;
   maxIterations: number | undefined;
+  maxRetryableAttempts: number | undefined;
 };
 
 export interface SecretRedactionContext {
@@ -329,6 +336,16 @@ export function parseRpcUrl(rpcUrl: string, envName: string): string {
     throw new Error("Invalid env " + envName);
   }
   return rpcUrl;
+}
+
+function parseOptionalRpcUrl(rpcUrl: unknown, envName: string): string | undefined {
+  if (rpcUrl === undefined) {
+    return undefined;
+  }
+  if (typeof rpcUrl !== "string") {
+    throw new Error("Invalid env " + envName);
+  }
+  return parseRpcUrl(rpcUrl, envName);
 }
 
 export function parseMaxIterations(
@@ -379,7 +396,8 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
       key !== "privateKey" &&
       key !== "rpcUrl" &&
       key !== "sleepIntervalSeconds" &&
-      key !== "maxIterations"
+      key !== "maxIterations" &&
+      key !== "maxRetryableAttempts"
     ) {
       throw new Error("Invalid env " + envName);
     }
@@ -387,9 +405,9 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
   if (
     typeof record.chain !== "string" ||
     typeof record.privateKey !== "string" ||
-    typeof record.rpcUrl !== "string" ||
     typeof record.sleepIntervalSeconds !== "number" ||
-    record.maxIterations !== undefined && typeof record.maxIterations !== "number"
+    record.maxIterations !== undefined && typeof record.maxIterations !== "number" ||
+    record.maxRetryableAttempts !== undefined && typeof record.maxRetryableAttempts !== "number"
   ) {
     throw new Error("Invalid env " + envName);
   }
@@ -400,9 +418,10 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
   return {
     chain: record.chain,
     privateKey: parsePrivateKey(record.privateKey, envName),
-    rpcUrl: parseRpcUrl(record.rpcUrl, envName),
+    rpcUrl: parseOptionalRpcUrl(record.rpcUrl, envName),
     sleepIntervalMs: parseSleepInterval(record.sleepIntervalSeconds, envName),
     maxIterations: parseMaxIterations(record.maxIterations, envName),
+    maxRetryableAttempts: parseMaxIterations(record.maxRetryableAttempts, envName),
   };
 }
 

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -306,8 +306,8 @@ export type RuntimeConfig = {
   privateKey: `0x${string}`;
   rpcUrl?: string;
   sleepIntervalMs: number;
-  maxIterations: number | undefined;
-  maxRetryableAttempts: number | undefined;
+  maxIterations?: number;
+  maxRetryableAttempts?: number;
 };
 
 export interface SecretRedactionContext {

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -419,7 +419,7 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
     privateKey: parsePrivateKey(record.privateKey, envName),
     rpcUrl: record.rpcUrl !== undefined ? parseRpcUrl(record.rpcUrl, envName) : undefined,
     sleepIntervalMs: parseSleepInterval(record.sleepIntervalSeconds, envName),
-    maxIterations: parsePositiveSafeInteger(record.maxIterations, envName),
+    maxIterations: parseMaxIterations(record.maxIterations, envName),
     maxRetryableAttempts: parsePositiveSafeInteger(record.maxRetryableAttempts, envName),
   };
 }

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -338,16 +338,6 @@ export function parseRpcUrl(rpcUrl: string, envName: string): string {
   return rpcUrl;
 }
 
-function parseOptionalRpcUrl(rpcUrl: unknown, envName: string): string | undefined {
-  if (rpcUrl === undefined) {
-    return undefined;
-  }
-  if (typeof rpcUrl !== "string") {
-    throw new Error("Invalid env " + envName);
-  }
-  return parseRpcUrl(rpcUrl, envName);
-}
-
 export function parseMaxIterations(
   value: number | undefined,
   envName: string,
@@ -406,6 +396,7 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
     typeof record.chain !== "string" ||
     typeof record.privateKey !== "string" ||
     typeof record.sleepIntervalSeconds !== "number" ||
+    (record.rpcUrl !== undefined && typeof record.rpcUrl !== "string") ||
     (record.maxIterations !== undefined && typeof record.maxIterations !== "number") ||
     (record.maxRetryableAttempts !== undefined && typeof record.maxRetryableAttempts !== "number")
   ) {
@@ -418,7 +409,7 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
   return {
     chain: record.chain,
     privateKey: parsePrivateKey(record.privateKey, envName),
-    rpcUrl: parseOptionalRpcUrl(record.rpcUrl, envName),
+    rpcUrl: record.rpcUrl !== undefined ? parseRpcUrl(record.rpcUrl, envName) : undefined,
     sleepIntervalMs: parseSleepInterval(record.sleepIntervalSeconds, envName),
     maxIterations: parseMaxIterations(record.maxIterations, envName),
     maxRetryableAttempts: parseMaxIterations(record.maxRetryableAttempts, envName),

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -346,6 +346,13 @@ export function parseMaxIterations(
   return parsePositiveSafeInteger(value, envName);
 }
 
+export function parseMaxRetryableAttempts(
+  value: number | undefined,
+  envName: string,
+): number | undefined {
+  return parsePositiveSafeInteger(value, envName);
+}
+
 function parsePositiveSafeInteger(
   value: number | undefined,
   envName: string,
@@ -420,7 +427,7 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
     rpcUrl: record.rpcUrl !== undefined ? parseRpcUrl(record.rpcUrl, envName) : undefined,
     sleepIntervalMs: parseSleepInterval(record.sleepIntervalSeconds, envName),
     maxIterations: parseMaxIterations(record.maxIterations, envName),
-    maxRetryableAttempts: parsePositiveSafeInteger(record.maxRetryableAttempts, envName),
+    maxRetryableAttempts: parseMaxRetryableAttempts(record.maxRetryableAttempts, envName),
   };
 }
 

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -283,7 +283,7 @@ export function parseSleepInterval(
   }
 
   const intervalMs = intervalSeconds * 1000;
-  if (!Number.isSafeInteger(intervalMs) || intervalMs > Math.floor(MAX_TIMER_DELAY_MS / 2)) {
+  if (!Number.isSafeInteger(intervalMs) || intervalMs > MAX_TIMER_DELAY_MS / 2) {
     throw new Error("Invalid env " + envName);
   }
 
@@ -406,8 +406,8 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
     typeof record.chain !== "string" ||
     typeof record.privateKey !== "string" ||
     typeof record.sleepIntervalSeconds !== "number" ||
-    record.maxIterations !== undefined && typeof record.maxIterations !== "number" ||
-    record.maxRetryableAttempts !== undefined && typeof record.maxRetryableAttempts !== "number"
+    (record.maxIterations !== undefined && typeof record.maxIterations !== "number") ||
+    (record.maxRetryableAttempts !== undefined && typeof record.maxRetryableAttempts !== "number")
   ) {
     throw new Error("Invalid env " + envName);
   }


### PR DESCRIPTION
## Why

Runtime configs should be able to rely on CCC's default public endpoint when no custom RPC URL is configured. Upcoming live tooling also needs a shared retry budget field without changing every app-specific config reader.

## Changes

- Allow runtime JSON configs to omit `rpcUrl` and pass `undefined` through `createPublicClient`.
- Add optional `maxRetryableAttempts` parsing to the shared runtime config shape.
- Reject sleep intervals that exceed Node's safe timer range before jitter doubles the value.
- Update bot/tester config-reader expectations for the expanded runtime config shape.
