### PR TITLE
fix(sdk): avoid final confirmation sleep

### DIFF
--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -1991,6 +1991,7 @@ describe("sendAndWaitForCommit", () => {
   it("surfaces transaction confirmation timeouts with the broadcast hash", async () => {
     const txHash = hash("a3");
     const onSent = vi.fn();
+    const sleep = vi.fn(() => Promise.resolve());
     const onLifecycle = vi.fn<(event: unknown) => void>();
 
     try {
@@ -2008,7 +2009,7 @@ describe("sendAndWaitForCommit", () => {
           maxConfirmationChecks: 1,
           onLifecycle,
           onSent,
-          sleep: () => Promise.resolve(),
+          sleep,
         },
       );
       expect.fail("Expected sendAndWaitForCommit to reject");
@@ -2023,6 +2024,7 @@ describe("sendAndWaitForCommit", () => {
     }
 
     expect(onSent).toHaveBeenCalledWith(txHash);
+    expect(sleep).not.toHaveBeenCalled();
     expect(onLifecycle.mock.calls.map(([event]) => event)).toMatchObject([
       { type: "broadcasted", txHash },
       { type: "timeout_after_broadcast", txHash, status: "unknown", checks: 1 },

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -253,6 +253,9 @@ export async function sendAndWaitForCommit(
     if (!isPendingStatus(status)) {
       break;
     }
+    if (checks >= maxConfirmationChecks) {
+      break;
+    }
 
     onConfirmationWait?.();
     await sleep(confirmationIntervalMs);

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -250,10 +250,7 @@ export async function sendAndWaitForCommit(
       lastPollingError = error;
     }
     checks += 1;
-    if (!isPendingStatus(status)) {
-      break;
-    }
-    if (checks >= maxConfirmationChecks) {
+    if (!isPendingStatus(status) || checks >= maxConfirmationChecks) {
       break;
     }
 


### PR DESCRIPTION
## Why
`sendAndWaitForCommit` could sleep after the final allowed confirmation check even though it was about to time out. With small `maxConfirmationChecks`, that added a full unnecessary interval after the last poll.

## Changes
- Stop confirmation polling immediately after the last allowed pending check.
- Cover the timeout path with an assertion that no final sleep occurs.