### PR TITLE
Add bot retry observability evidence

### DIFF
--- a/apps/bot/README.md
+++ b/apps/bot/README.md
@@ -13,10 +13,20 @@ The bot minimizes excess iCKB holdings so more liquidity stays available in CKB 
 The bot reads one strict JSON config file named by `BOT_CONFIG_FILE`:
 
 ```json
-{"chain":"testnet","privateKey":"0x...","sleepIntervalSeconds":60,"maxRetryableAttempts":10}
+{"chain":"testnet","privateKey":"0x...","rpcUrl":"http://127.0.0.1:8114/","sleepIntervalSeconds":60,"maxIterations":1,"maxRetryableAttempts":10}
 ```
 
-The JSON config accepts exactly `chain`, `privateKey`, optional `rpcUrl`, `sleepIntervalSeconds`, optional `maxIterations`, and optional `maxRetryableAttempts`. Unknown keys, wrong types, non-HTTP(S) RPC URLs, whitespace/control characters in `rpcUrl`, and non-canonical private keys are rejected. Omitting `rpcUrl` lets CCC use its default endpoint. The private key must be exactly lowercase `0x` plus 64 lowercase hex characters, with no newline, spaces, tabs, or comments. Local config files under `config/` are ignored by git.
+The JSON config accepts exactly `chain`, `privateKey`, optional `rpcUrl`, `sleepIntervalSeconds`, optional `maxIterations`, and optional `maxRetryableAttempts`. Omit `rpcUrl` to let CCC use its default public endpoint for the selected chain. Unknown keys, wrong types, empty/non-HTTP(S) RPC URLs, whitespace/control characters in `rpcUrl`, and non-canonical private keys are rejected. The private key must be exactly lowercase `0x` plus 64 lowercase hex characters, with no newline, spaces, tabs, or comments. Local config files under `config/` are ignored by git.
+
+For local testnet live supervision, keep funded identities in external environment variables and rebuild disposable ignored configs when needed:
+
+```bash
+export ICKB_TESTNET_BOT_PRIVATE_KEY='0x...'
+export ICKB_TESTNET_TESTER_PRIVATE_KEY='0x...'
+# Optional: export ICKB_TESTNET_RPC_URL='https://...'
+# Optional: export ICKB_TESTNET_MAX_RETRYABLE_ATTEMPTS=10
+pnpm live:config-from-env -- --force
+```
 
 Current network support:
 
@@ -58,6 +68,7 @@ The stable event contract is the bot NDJSON object stream, not a particular file
 Stable event types:
 
 - `bot.run.started`
+- `bot.chain.preflight`
 - `bot.iteration.started`
 - `bot.state.read`
 - `bot.match.evaluated`
@@ -70,13 +81,17 @@ Stable event types:
 - `bot.transaction.failed`
 - `bot.iteration.failed`
 
-No-action iterations emit `bot.decision.skipped` with `reason` and evidence. Build-time skip reasons `no_actions` and `match_value_not_above_fee` include a `decision` transcript. The pre-build safety skip `capital_below_minimum` exits with code `2` and includes zero `actions` plus `state` evidence instead of a `decision` transcript because match, rebalance, fee, and transaction shape were not evaluated. `bot.iteration.failed` includes a redacted `error` summary plus `retryable` and `terminal` booleans from the bot retry policy. Rebalance no-op decisions include policy-owned reasons such as `insufficient_output_slots`, `low_ickb_ckb_reserve_unavailable`, `target_ickb_not_exceeded`, and `no_ready_withdrawal_selection`.
+`bot.chain.preflight` emits public chain identity evidence before signing starts: whether a custom RPC URL was configured, expected chain identity, observed genesis hash/address prefix/tip, and match booleans. It does not print the RPC URL because configured URLs may contain credentials. No-action iterations emit `bot.decision.skipped` with `reason` and evidence. Build-time skip reasons `no_actions`, `match_value_not_above_fee`, and `post_tx_ckb_reserve` include a `decision` transcript. Reserve skips report zero committed `actions` and keep attempted action counts under `decision.skip.attemptedActions` because the transaction was not broadcast. The pre-build safety skip `capital_below_minimum` exits with code `2` and includes zero `actions`, `deficit`, and `state` evidence instead of a `decision` transcript because match, rebalance, fee, and transaction shape were not evaluated. `bot.iteration.failed` includes an `error` summary plus `retryable` and `terminal` booleans from the bot retry policy. Rebalance decisions include normalized `reason`; no-op reasons remain policy-owned strings such as `insufficient_output_slots`, `low_ickb_ckb_reserve_unavailable`, `target_ickb_not_exceeded`, and `no_ready_withdrawal_selection`.
 
-The decision transcript groups evidence under `chainTip`, `balances`, `orders`, `withdrawals`, `poolDeposits`, `match`, `rebalance`, `actions`, `fee`, `transactionShape`, `exchangeRatio`, and `depositCapacity`. Transaction events summarize action counts, fee, fee rate, tx hash, confirmation status, check count, elapsed time, and transaction shape counts.
+The decision transcript groups evidence under `chainTip`, `balances`, `orders`, `withdrawals`, `poolDeposits`, `match`, `rebalance`, `actions`, `fee`, `transactionShape`, `exchangeRatio`, and `depositCapacity`. `balances` includes available, unavailable, total, equivalent, minimum-capital, and spendable CKB evidence. `match.reason` normalizes the matching outcome, while `match.diagnostics` carries public allowance, mining fee, direction counts, candidate counts, positive-gain counts, and rejection counts. `rebalance` carries kind, reason, projected balances, output slots, pool/deposit/withdrawal counts, and policy diagnostics. `fee.feeRate` is included on state and decision events.
 
-JSON `"maxIterations":1` makes `pnpm --filter ./apps/bot start` exit with code `0` after one terminal iteration when that terminal outcome is a skipped decision, committed transaction, non-safety transaction failure, or non-safety iteration failure. Retryable iteration failures are logged with `terminal:false` and do not count toward `maxIterations`. Safety stops still keep their nonzero behavior: low capital and confirmation timeouts after broadcast exit with code `2`. Omitting `maxIterations` keeps the default infinite loop.
+Transaction events summarize action counts, fee, fee rate, tx hash, phase, outcome, confirmation status, check count, elapsed time, retryable/terminal policy, and transaction shape counts. Error summaries preserve non-secret enumerable error fields. This keeps CKB/CCC send rejection evidence such as `code`, `data`, `outPoint`, `currentFee`, and `leastFee` visible in `bot.transaction.failed` and `bot.iteration.failed`. Non-secret debugging data may be logged when useful, including raw transactions, witnesses, public config fields, noncredentialed RPC identity evidence, scripts, cells, hashes, counts, and summaries.
 
-Structured events should contain public evidence and summaries needed to understand bot behavior. Do not add private keys, seed phrases, mnemonics, or other secrets to log payloads; omit noisy public fields at the call site instead of relying on redaction.
+Observed testnet full-node send rejection signatures for generic stale-state races are: in-pool same-input conflict can return `code:-1111` with `data:"RBFRejected(...)"` and CCC fields `currentFee`/`leastFee`; a post-commit spent input returns `code:-301` with `data:"Resolve(Unknown(OutPoint(...)))"` and CCC field `outPoint`; resending the same tx returns `code:-1107` with `data:"Duplicated(Byte32(...))"` and CCC field `txHash`. CKB source also has a `Resolve(Dead(OutPoint(...)))` path for some pool conflicts. Treat these as retry candidates only when the bot discards the transaction and rebuilds from fresh state, not by blindly resending the same transaction.
+
+JSON `"maxIterations":1` makes `pnpm --filter ./apps/bot start` exit with code `0` after one terminal iteration when that terminal outcome is a skipped decision, committed transaction, non-safety transaction failure, or non-safety iteration failure. Retryable iteration failures do not count toward `maxIterations`; set `maxRetryableAttempts` to stop repeated fresh-state retries with exit code `2` after that many consecutive retryable failures. Safety stops still keep their nonzero behavior: low capital and confirmation timeouts after broadcast exit with code `2`. Omitting `maxIterations` keeps the default infinite loop; omitting `maxRetryableAttempts` leaves retryable attempts unbounded.
+
+Structured events should contain evidence needed to understand bot behavior. The bot must not print its configured private key to events, execution logs, errors, stdout, or stderr. Private keys are for signing only: logger, event, and error helpers must not receive private keys, secret contexts, masking callbacks, redaction parameters, or guard inputs. Tests use a configured canary private key from outside the production path and verify produced output cannot reveal it, even unlabeled or nested in arbitrary text. Secrets, credentialed RPC URLs, tokens, passwords, API keys, and secret-bearing config/env dumps must not be logged or passed to logging, redaction, masking, or guard helpers.
 
 Bot-only log queries, using the production event file or any saved bot stdout NDJSON stream:
 
@@ -84,6 +99,11 @@ Bot-only log queries, using the production event file or any saved bot stdout ND
 LOG_DIR=/opt/ickb-stack-testnet/log/bot/testnet
 jq -c 'select(.app == "bot")' "$LOG_DIR/bot.events.ndjson"
 jq -r 'select(.app == "bot") | .type' "$LOG_DIR/bot.events.ndjson" | sort | uniq -c
+jq -c 'select(.app == "bot" and .type == "bot.chain.preflight") | {timestamp, chain, rpcConfigured, expected, observed, matches}' "$LOG_DIR/bot.events.ndjson"
+jq -c 'select(.app == "bot" and .type == "bot.decision.skipped") | {timestamp, chain, runId, iterationId, reason, actions, deficit, state, skip: .decision.skip}' "$LOG_DIR/bot.events.ndjson"
+jq -c 'select(.app == "bot" and .type == "bot.match.evaluated") | {timestamp, iterationId, reason: .match.reason, orders, diagnostics: .match.diagnostics}' "$LOG_DIR/bot.events.ndjson"
+jq -c 'select(.app == "bot" and .type == "bot.rebalance.evaluated") | {timestamp, iterationId, rebalance, poolDeposits}' "$LOG_DIR/bot.events.ndjson"
+jq -c 'select(.app == "bot" and (.type == "bot.transaction.failed" or .type == "bot.iteration.failed")) | {timestamp, chain, runId, iterationId, type, phase, outcome, retryable, terminal, retryableAttempts, maxRetryableAttempts, retryBudgetExhausted, txHash, status, checks, elapsedMs, error}' "$LOG_DIR/bot.events.ndjson"
 jq -c 'select(.type == "launcher.child.exited") | {timestamp, status, signal, elapsedMs, logRoot, logDir, command}' "$LOG_DIR/launches.ndjson"
 ```
 

--- a/apps/bot/src/index.test.ts
+++ b/apps/bot/src/index.test.ts
@@ -9,7 +9,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { TARGET_ICKB_BALANCE } from "./policy.js";
+import { CKB_RESERVE, TARGET_ICKB_BALANCE } from "./policy.js";
 import {
   completeTerminalIteration,
   isRetryableBotError,
@@ -467,7 +467,7 @@ describe("buildTransaction", () => {
 
   it("skips built transactions that would violate the bot plain CKB reserve", async () => {
     const lock = script("11");
-    const spent = capacityCell(1000n, lock, "77");
+    const spent = capacityCell(CKB_RESERVE + 100n, lock, "77");
     vi.spyOn(OrderManager, "bestMatch").mockReturnValue({
       ckbDelta: -1n,
       udtDelta: 0n,
@@ -476,6 +476,14 @@ describe("buildTransaction", () => {
     vi.spyOn(ccc.Transaction.prototype, "estimateFee").mockReturnValue(1n);
     const runtime = botRuntime({
       primaryLock: lock,
+      managers: {
+        logic: {
+          deposit: async (txLike: ccc.TransactionLike): Promise<ccc.Transaction> => {
+            await Promise.resolve();
+            return ccc.Transaction.from(txLike);
+          },
+        },
+      },
       sdk: {
         completeTransaction: async (txLike: ccc.TransactionLike): Promise<ccc.Transaction> => {
           await Promise.resolve();
@@ -490,9 +498,9 @@ describe("buildTransaction", () => {
       accountLocks: [lock],
       capacityCells: [spent],
       marketOrders: [{}],
-      availableCkbBalance: ccc.fixedPointFrom(5000),
+      availableCkbBalance: CKB_RESERVE + 100n,
       availableIckbBalance: TARGET_ICKB_BALANCE,
-      totalCkbBalance: ccc.fixedPointFrom(5000),
+      totalCkbBalance: CKB_RESERVE + 100n,
     });
 
     const result = await buildTransaction(runtime as never, state as never);
@@ -502,7 +510,7 @@ describe("buildTransaction", () => {
       reason: "post_tx_ckb_reserve",
       decision: {
         balances: {
-          spendableCkb: ccc.fixedPointFrom(4000),
+          spendableCkb: 100n,
         },
         skip: {
           reason: "post_tx_ckb_reserve",
@@ -520,7 +528,6 @@ describe("buildTransaction", () => {
 
   it("allows CKB-replenishing transactions even when plain CKB remains below reserve", async () => {
     const lock = script("11");
-    const spent = capacityCell(1000n, lock, "78");
     vi.spyOn(OrderManager, "bestMatch").mockReturnValue({
       ckbDelta: 1n,
       udtDelta: 0n,
@@ -533,19 +540,18 @@ describe("buildTransaction", () => {
         completeTransaction: async (txLike: ccc.TransactionLike): Promise<ccc.Transaction> => {
           await Promise.resolve();
           const tx = ccc.Transaction.from(txLike);
-          tx.inputs.push(ccc.CellInput.from({ previousOutput: spent.outPoint }));
-          tx.addOutput({ capacity: 1n, lock });
+          tx.addOutput({ capacity: ccc.fixedPointFrom(500), lock });
           return tx;
         },
       },
     });
     const state = botState({
       accountLocks: [lock],
-      capacityCells: [spent],
+      capacityCells: [],
       readyWithdrawals: [{}],
-      availableCkbBalance: 1000n,
+      availableCkbBalance: ccc.fixedPointFrom(2000),
       availableIckbBalance: TARGET_ICKB_BALANCE,
-      totalCkbBalance: 1000n,
+      totalCkbBalance: ccc.fixedPointFrom(2000),
     });
 
     const result = await buildTransaction(runtime as never, state as never);
@@ -553,6 +559,48 @@ describe("buildTransaction", () => {
     expect(result).toMatchObject({
       kind: "built",
       actions: { withdrawals: 1 },
+    });
+    expect(result.decision.skip).toBeUndefined();
+  });
+
+  it("allows withdrawal requests to spend reserve CKB for recovery state rent", async () => {
+    const lock = script("11");
+    const rent = capacityCell(100n, lock, "80");
+    vi.spyOn(OrderManager, "bestMatch").mockReturnValue({
+      ckbDelta: 0n,
+      udtDelta: 0n,
+      partials: [],
+    });
+    vi.spyOn(ccc.Transaction.prototype, "estimateFee").mockReturnValue(1n);
+    const runtime = botRuntime({
+      primaryLock: lock,
+      sdk: {
+        completeTransaction: async (txLike: ccc.TransactionLike): Promise<ccc.Transaction> => {
+          await Promise.resolve();
+          const tx = ccc.Transaction.from(txLike);
+          tx.inputs.push(ccc.CellInput.from({ previousOutput: rent.outPoint }));
+          return tx;
+        },
+      },
+    });
+    const first = readyDeposit("79", 4n, 20n * 60n * 1000n);
+    const protectedAnchor = readyDeposit("7a", 6n, 25n * 60n * 1000n);
+    const third = readyDeposit("7b", 5n, 40n * 60n * 1000n);
+    const state = botState({
+      accountLocks: [lock],
+      capacityCells: [rent],
+      availableCkbBalance: 0n,
+      availableIckbBalance: TARGET_ICKB_BALANCE + 9n,
+      totalCkbBalance: 0n,
+      depositCapacity: 1000n,
+      readyPoolDeposits: [first, protectedAnchor, third],
+    });
+
+    const result = await buildTransaction(runtime as never, state as never);
+
+    expect(result).toMatchObject({
+      kind: "built",
+      actions: { withdrawalRequests: 1 },
     });
     expect(result.decision.skip).toBeUndefined();
   });

--- a/apps/bot/src/index.test.ts
+++ b/apps/bot/src/index.test.ts
@@ -1,5 +1,6 @@
 import { ccc } from "@ckb-ccc/core";
 import { type IckbDepositCell } from "@ickb/core";
+import { handleLoopError, logExecution } from "@ickb/node-utils";
 import { OrderManager } from "@ickb/order";
 import { type IckbSdk } from "@ickb/sdk";
 import { defaultFindCellsLimit } from "@ickb/utils";
@@ -13,9 +14,12 @@ import {
   completeTerminalIteration,
   isRetryableBotError,
   iterationFailureEventFields,
+  readBotState,
   readBotRuntimeConfig,
+  reachedMaxRetryableAttempts,
 } from "./index.js";
-import { buildTransaction, collectPoolDeposits, postTransactionPlainCkbBalance } from "./runtime.js";
+import { BotEventEmitter, transactionLifecycleEvents } from "./observability.js";
+import { buildTransaction, collectPoolDeposits } from "./runtime.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -85,11 +89,16 @@ function botRuntime(overrides: {
   sdk?: Partial<{
     buildBaseTransaction: IckbSdk["buildBaseTransaction"];
     completeTransaction: IckbSdk["completeTransaction"];
+    getL1AccountState: IckbSdk["getL1AccountState"];
+    assertCurrentTip: IckbSdk["assertCurrentTip"];
   }>;
   primaryLock?: ccc.Script;
+  managers?: Record<string, unknown>;
 } = {}): Record<string, unknown> {
   const client: ccc.Client = {};
-  const signer: ccc.SignerCkbPrivateKey = {};
+  const signer: ccc.SignerCkbPrivateKey = {
+    getAddressObjs: () => Promise.resolve([]),
+  } as never;
 
   return {
     client,
@@ -103,6 +112,7 @@ function botRuntime(overrides: {
         deposit: (txLike: ccc.TransactionLike): Promise<ccc.Transaction> =>
           Promise.resolve(ccc.Transaction.from(txLike)),
       },
+      ...(overrides.managers ?? {}),
     },
     sdk: {
       buildBaseTransaction: async (
@@ -116,6 +126,25 @@ function botRuntime(overrides: {
       ): Promise<ccc.Transaction> => {
         await Promise.resolve();
         return ccc.Transaction.from(txLike);
+      },
+      getL1AccountState: async (): Promise<unknown> => {
+        await Promise.resolve();
+        return {
+          system: {
+            tip: headerLike(),
+            exchangeRatio: { ckbScale: 1n, udtScale: 1n },
+            orderPool: [],
+            feeRate: 1n,
+          },
+          user: { orders: [] },
+          account: {
+            capacityCells: [],
+            receipts: [],
+          },
+        };
+      },
+      assertCurrentTip: async (): Promise<void> => {
+        await Promise.resolve();
       },
       ...overrides.sdk,
     },
@@ -151,6 +180,49 @@ describe("collectPoolDeposits", () => {
   });
 });
 
+describe("readBotState", () => {
+  it("fails closed when pool scans cross the account-state tip", async () => {
+    const tip = headerLike({ number: 10n });
+    const assertCurrentTip = vi.fn(async () => {
+      await Promise.resolve();
+      throw new Error("L1 state scan crossed chain tip; retry with a fresh state");
+    });
+    const runtime = botRuntime({
+      sdk: {
+        getL1AccountState: async (): Promise<unknown> => {
+          await Promise.resolve();
+          return {
+            system: {
+              tip,
+              exchangeRatio: { ckbScale: 1n, udtScale: 1n },
+              orderPool: [],
+              feeRate: 1n,
+            },
+            user: { orders: [] },
+            account: { capacityCells: [], receipts: [] },
+          };
+        },
+        assertCurrentTip,
+      },
+      managers: {
+        logic: {
+          findDeposits: async function* (): AsyncGenerator<IckbDepositCell> {
+            await Promise.resolve();
+            for (const deposit of [] as IckbDepositCell[]) {
+              yield deposit;
+            }
+          },
+        },
+      },
+    });
+
+    await expect(readBotState(runtime as never)).rejects.toThrow(
+      "L1 state scan crossed chain tip; retry with a fresh state",
+    );
+    expect(assertCurrentTip).toHaveBeenCalledWith(runtime.client, tip);
+  });
+});
+
 describe("completeTerminalIteration", () => {
   it("counts only terminal iterations toward bounded runs", () => {
     expect(completeTerminalIteration(0, 1)).toEqual({
@@ -168,11 +240,37 @@ describe("completeTerminalIteration", () => {
   });
 });
 
+describe("reachedMaxRetryableAttempts", () => {
+  it("uses a separate retryable-attempt budget", () => {
+    expect(reachedMaxRetryableAttempts(1, 1)).toBe(true);
+    expect(reachedMaxRetryableAttempts(1, 2)).toBe(false);
+    expect(reachedMaxRetryableAttempts(999, undefined)).toBe(false);
+  });
+});
+
 describe("bot retryable iteration failures", () => {
-  it("treats chain-tip races and fetch transport failures as retryable", () => {
+  it("treats transport and CKB state-race failures as retryable", () => {
     expect(isRetryableBotError(new Error("L1 state scan crossed chain tip; retry with a fresh state"))).toBe(true);
     expect(isRetryableBotError(new TypeError("fetch failed"))).toBe(true);
+    expect(isRetryableBotError(new Error("fetch failed", { cause: new TypeError("fetch failed") }))).toBe(true);
+    expect(isRetryableBotError(Object.assign(new Error("Client request error PoolRejectedRBF"), {
+      code: -1111,
+      data: "RBFRejected(\"Tx's current fee is 11795, expect it to >= 12326 to replace old txs\")",
+    }))).toBe(true);
+    expect(isRetryableBotError(Object.assign(new Error("Client request error TransactionFailedToResolve"), {
+      code: -301,
+      data: `Resolve(Unknown(OutPoint(0x${"11".repeat(32)}00000000)))`,
+    }))).toBe(true);
+    expect(isRetryableBotError({
+      code: -301,
+      data: `Resolve(Dead(OutPoint(0x${"11".repeat(32)}00000000)))`,
+    })).toBe(true);
+    expect(isRetryableBotError(Object.assign(new Error("Client request error PoolRejectedDuplicatedTransaction"), {
+      code: -1107,
+      data: `Duplicated(Byte32(0x${"22".repeat(32)}))`,
+    }))).toBe(true);
     expect(isRetryableBotError(new Error("fetch failed"))).toBe(false);
+    expect(isRetryableBotError({ code: -301, data: "Resolve(InvalidHeader(Byte32(0x...)))" })).toBe(false);
     expect(isRetryableBotError(new Error("deterministic build failure"))).toBe(false);
   });
 
@@ -182,12 +280,112 @@ describe("bot retryable iteration failures", () => {
       terminal: false,
       error: { name: "TypeError", message: "fetch failed" },
     });
+    expect(iterationFailureEventFields(new TypeError("fetch failed")).error).not.toHaveProperty("stack");
 
-    expect(iterationFailureEventFields(new Error("deterministic build failure"))).toMatchObject({
+    const stateRaceFailure = iterationFailureEventFields(Object.assign(new Error("Client request error TransactionFailedToResolve"), {
+      code: -301,
+      data: `Resolve(Unknown(OutPoint(0x${"11".repeat(32)}00000000)))`,
+    }));
+    expect(stateRaceFailure).toMatchObject({ retryable: true, terminal: false });
+    expect(stateRaceFailure.error).not.toHaveProperty("stack");
+
+    const exhaustedFailure = iterationFailureEventFields(new TypeError("fetch failed"), {
+      retryableAttempts: 3,
+      maxRetryableAttempts: 3,
+    });
+    expect(exhaustedFailure).toMatchObject({
+      retryable: true,
+      terminal: true,
+      retryableAttempts: 3,
+      maxRetryableAttempts: 3,
+      retryBudgetExhausted: true,
+    });
+    expect(exhaustedFailure.error).not.toHaveProperty("stack");
+
+    expect(iterationFailureEventFields(new TypeError("fetch failed"), {
+      retryableAttempts: 3,
+      maxRetryableAttempts: undefined,
+    })).toMatchObject({
+      retryable: true,
+      terminal: false,
+      retryableAttempts: 3,
+      retryBudgetExhausted: false,
+    });
+
+    const terminalFailure = iterationFailureEventFields(new Error("deterministic build failure"));
+    expect(terminalFailure).toMatchObject({
       retryable: false,
       terminal: true,
       error: { name: "Error", message: "deterministic build failure" },
     });
+    expect(terminalFailure.error).toHaveProperty("stack");
+  });
+});
+
+describe("bot private key output boundary", () => {
+  it("does not leak the configured canary key across representative crash outputs", async () => {
+    const privateKey = `0x${"42".repeat(32)}`;
+    const dir = await mkdtemp(join(tmpdir(), "ickb-bot-private-key-boundary-"));
+    const output: string[] = [];
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      output.push(String(chunk));
+      return true;
+    });
+    try {
+      const configPath = join(dir, "config.json");
+      await writeFile(configPath, JSON.stringify({
+        chain: "testnet",
+        privateKey,
+        sleepIntervalSeconds: 60,
+        maxIterations: 1,
+      }), { mode: 0o600 });
+      const runtimeConfig = await readBotRuntimeConfig({ BOT_CONFIG_FILE: configPath });
+      const emitter = new BotEventEmitter({
+        chain: runtimeConfig.chain,
+        runId: "run-canary-test",
+        write: (event): void => {
+          output.push(JSON.stringify(event));
+        },
+      });
+      emitter.emit(0, "bot.run.started", {
+        runtime: {
+          maxIterations: runtimeConfig.maxIterations,
+          maxRetryableAttempts: runtimeConfig.maxRetryableAttempts,
+          bounded: runtimeConfig.maxIterations !== undefined,
+          sleepIntervalMs: runtimeConfig.sleepIntervalMs,
+          rpcConfigured: runtimeConfig.rpcUrl !== undefined,
+        },
+      });
+      emitter.emit(0, "bot.chain.preflight", {
+        rpcConfigured: runtimeConfig.rpcUrl !== undefined,
+        expected: { chain: "testnet", genesisHash: hash("11"), addressPrefix: "ckt" },
+        observed: {
+          genesisHash: hash("11"),
+          addressPrefix: "ckt",
+          tip: { hash: hash("22"), number: 1n, timestamp: 2n },
+        },
+        matches: { genesisHash: true, addressPrefix: true },
+      });
+      const executionLog: Record<string, unknown> = { startTime: "fixture" };
+      handleLoopError(executionLog, new Error("deterministic crash"));
+      logExecution(executionLog, new Date());
+      emitter.emit(1, "bot.iteration.failed", iterationFailureEventFields(new TypeError("fetch failed")));
+      for (const lifecycle of transactionLifecycleEvents({
+        type: "pre_broadcast_failed",
+        elapsedMs: 1,
+        error: new TypeError("fetch failed"),
+      })) {
+        emitter.emit(1, lifecycle.type, lifecycle.fields);
+      }
+
+      const capturedCrashLog = output.join("\n");
+
+      expect(runtimeConfig.privateKey).toBe(privateKey);
+      expect(capturedCrashLog).not.toContain(privateKey);
+    } finally {
+      stdoutWrite.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -207,12 +405,38 @@ describe("readBotRuntimeConfig", () => {
         rpcUrl: "http://127.0.0.1:8114/",
         sleepIntervalSeconds: 60,
         maxIterations: 1,
+        maxRetryableAttempts: 3,
       }), { mode: 0o600 });
 
       await expect(readBotRuntimeConfig({ BOT_CONFIG_FILE: configPath })).resolves.toEqual({
         chain: "testnet",
         privateKey,
         rpcUrl: "http://127.0.0.1:8114/",
+        sleepIntervalMs: 60000,
+        maxIterations: 1,
+        maxRetryableAttempts: 3,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads JSON config files that omit custom RPC URLs", async () => {
+    const privateKey = `0x${"11".repeat(32)}`;
+    const dir = await mkdtemp(join(tmpdir(), "ickb-bot-config-"));
+    try {
+      const configPath = join(dir, "config.json");
+      await writeFile(configPath, JSON.stringify({
+        chain: "testnet",
+        privateKey,
+        sleepIntervalSeconds: 60,
+        maxIterations: 1,
+      }), { mode: 0o600 });
+
+      await expect(readBotRuntimeConfig({ BOT_CONFIG_FILE: configPath })).resolves.toEqual({
+        chain: "testnet",
+        privateKey,
+        rpcUrl: undefined,
         sleepIntervalMs: 60000,
         maxIterations: 1,
         maxRetryableAttempts: undefined,
@@ -271,11 +495,27 @@ describe("buildTransaction", () => {
       totalCkbBalance: ccc.fixedPointFrom(5000),
     });
 
-    await expect(buildTransaction(runtime as never, state as never)).resolves.toMatchObject({
+    const result = await buildTransaction(runtime as never, state as never);
+
+    expect(result).toMatchObject({
       kind: "skipped",
       reason: "post_tx_ckb_reserve",
-      decision: { skip: { reason: "post_tx_ckb_reserve" } },
+      decision: {
+        balances: {
+          spendableCkb: ccc.fixedPointFrom(4000),
+        },
+        skip: {
+          reason: "post_tx_ckb_reserve",
+          reserve: ccc.fixedPointFrom(1000),
+        },
+      },
     });
+    if (result.kind !== "skipped" || result.decision.skip?.postTxCkbBalance === undefined || result.decision.skip.deficit === undefined) {
+      throw new Error("Expected reserve skip details");
+    }
+    expect(result.decision.skip.deficit).toBe(
+      ccc.fixedPointFrom(1000) - result.decision.skip.postTxCkbBalance,
+    );
   });
 
   it("allows CKB-replenishing transactions even when plain CKB remains below reserve", async () => {
@@ -379,6 +619,35 @@ describe("buildTransaction", () => {
     });
   });
 
+  it("labels built match and deposit-rebalance decisions", async () => {
+    vi.spyOn(OrderManager, "bestMatch").mockReturnValue({
+      ckbDelta: 0n,
+      udtDelta: 1n,
+      partials: [{} as never],
+    });
+    vi.spyOn(ccc.Transaction.prototype, "estimateFee").mockReturnValue(1n);
+
+    const lock = script("11");
+    const runtime = botRuntime({ primaryLock: lock });
+    const state = botState({
+      accountLocks: [lock],
+      capacityCells: [capacityCell(ccc.fixedPointFrom(2000), lock, "69")],
+      marketOrders: [{}],
+      availableCkbBalance: ccc.fixedPointFrom(2000),
+      availableIckbBalance: 0n,
+      depositCapacity: 100n,
+      totalCkbBalance: ccc.fixedPointFrom(2000),
+    });
+
+    await expect(buildTransaction(runtime as never, state as never)).resolves.toMatchObject({
+      kind: "built",
+      decision: {
+        match: { reason: "matched" },
+        rebalance: { kind: "deposit", reason: "low_ickb_balance" },
+      },
+    });
+  });
+
   it("returns a structured no-action skip with rebalance reason", async () => {
     vi.spyOn(OrderManager, "bestMatch").mockReturnValue({
       ckbDelta: 0n,
@@ -413,6 +682,7 @@ describe("buildTransaction", () => {
     const completeTransaction = vi.fn();
     const runtime = botRuntime({ sdk: { completeTransaction } });
     const state = botState({
+      marketOrders: [{}],
       availableCkbBalance: 0n,
       availableIckbBalance: TARGET_ICKB_BALANCE,
     });
@@ -423,6 +693,7 @@ describe("buildTransaction", () => {
       decision: {
         rebalance: { kind: "none", reason: "target_ickb_not_exceeded" },
         match: {
+          reason: "no_positive_gain",
           diagnostics: {
             orderCount: 1,
             directions: {
@@ -508,38 +779,6 @@ describe("buildTransaction", () => {
     expect(completeTransaction).toHaveBeenCalledTimes(1);
     expect(calls).toEqual(["base", "complete"]);
     expect(result.tx.cellDeps).toEqual([]);
-  });
-});
-
-describe("postTransactionPlainCkbBalance", () => {
-  it("counts unspent account plain CKB plus account plain outputs", () => {
-    const lock = script("11");
-    const otherLock = script("22");
-    const spent = capacityCell(ccc.fixedPointFrom(1000), lock, "aa");
-    const unspent = capacityCell(ccc.fixedPointFrom(2000), lock, "bb");
-    const typed = ccc.Cell.from({
-      outPoint: { txHash: hash("cc"), index: 0n },
-      cellOutput: { capacity: ccc.fixedPointFrom(4000), lock, type: script("33") },
-      outputData: "0x",
-    });
-    const data = ccc.Cell.from({
-      outPoint: { txHash: hash("dd"), index: 0n },
-      cellOutput: { capacity: ccc.fixedPointFrom(8000), lock },
-      outputData: "0x1234",
-    });
-    const tx = ccc.Transaction.default();
-    tx.inputs.push(ccc.CellInput.from({ previousOutput: spent.outPoint }));
-    tx.outputs.push(
-      ccc.CellOutput.from({ capacity: ccc.fixedPointFrom(300), lock }),
-      ccc.CellOutput.from({ capacity: ccc.fixedPointFrom(500), lock, type: script("33") }),
-      ccc.CellOutput.from({ capacity: ccc.fixedPointFrom(700), lock: otherLock }),
-    );
-    tx.outputsData.push("0x", "0x", "0x");
-
-    expect(postTransactionPlainCkbBalance(
-      tx,
-      botState({ accountLocks: [lock], capacityCells: [spent, unspent, typed, data] }) as never,
-    )).toBe(ccc.fixedPointFrom(2300));
   });
 });
 

--- a/apps/bot/src/index.test.ts
+++ b/apps/bot/src/index.test.ts
@@ -4,7 +4,7 @@ import { handleLoopError, logExecution } from "@ickb/node-utils";
 import { OrderManager } from "@ickb/order";
 import { type IckbSdk } from "@ickb/sdk";
 import { defaultFindCellsLimit } from "@ickb/utils";
-import { headerLike } from "@ickb/testkit";
+import { hash, headerLike, script } from "@ickb/testkit";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -24,18 +24,6 @@ import { buildTransaction, collectPoolDeposits } from "./runtime.js";
 afterEach(() => {
   vi.restoreAllMocks();
 });
-
-function hash(byte: string): `0x${string}` {
-  return `0x${byte.repeat(32)}`;
-}
-
-function script(byte: string): ccc.Script {
-  return ccc.Script.from({
-    codeHash: hash(byte),
-    hashType: "type",
-    args: "0x",
-  });
-}
 
 function readyDeposit(
   byte: string,
@@ -374,7 +362,7 @@ describe("bot private key output boundary", () => {
         type: "pre_broadcast_failed",
         elapsedMs: 1,
         error: new TypeError("fetch failed"),
-      })) {
+      }, isRetryableBotError)) {
         emitter.emit(1, lifecycle.type, lifecycle.fields);
       }
 

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -162,15 +162,17 @@ async function main(): Promise<void> {
         });
       }
     } catch (error) {
-      let failure = iterationFailureEventFields(error);
-      if (failure.retryable) {
+      const retryable = isRetryableBotError(error);
+      if (retryable) {
         retryableAttempt = true;
         retryableAttempts += 1;
-        failure = iterationFailureEventFields(error, {
+      }
+      const failure = retryable
+        ? iterationFailureEventFields(error, {
           retryableAttempts,
           maxRetryableAttempts,
-        });
-      }
+        })
+        : iterationFailureEventFields(error);
       events.emit(iterationId, "bot.iteration.failed", failure);
       if (failure.retryable) {
         executionLog.error = failure.error;

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -11,6 +11,8 @@ import {
   createPublicClient,
   formatCkb,
   handleLoopError,
+  isRetryableCkbStateRaceError,
+  isRetryableRpcTransportError,
   logExecution,
   randomSleepIntervalMs,
   readRuntimeConfigEnv,
@@ -19,7 +21,6 @@ import {
   sleep,
   STOP_EXIT_CODE,
   type RuntimeConfig,
-  type SecretRedactionContext,
   verifyChainPreflight,
 } from "@ickb/node-utils";
 import {
@@ -41,16 +42,28 @@ import {
 
 async function main(): Promise<void> {
   const runtimeConfig = await readBotRuntimeConfig(process.env);
-  const { chain, privateKey, rpcUrl, sleepIntervalMs, maxIterations } = runtimeConfig;
-  const secrets = { privateKey, rpcUrl };
+  const { chain, privateKey, rpcUrl, sleepIntervalMs, maxIterations, maxRetryableAttempts } = runtimeConfig;
   const runId = createRunId();
   const events = new BotEventEmitter({ chain, runId });
   events.emit(0, "bot.run.started", {
     maxIterations,
     bounded: maxIterations !== undefined,
+    runtime: {
+      maxIterations,
+      bounded: maxIterations !== undefined,
+      sleepIntervalMs,
+      maxRetryableAttempts,
+      rpcConfigured: rpcUrl !== undefined,
+    },
   });
   const client = createPublicClient(chain, rpcUrl);
-  await verifyChainPreflight(client, chain);
+  const preflight = await verifyChainPreflight(client, chain);
+  events.emit(0, "bot.chain.preflight", {
+    rpcConfigured: rpcUrl !== undefined,
+    expected: preflight.expected,
+    observed: preflight.observed,
+    matches: preflight.matches,
+  });
   const config = getConfig(chain);
   const { managers } = config;
   const signer = new ccc.SignerCkbPrivateKey(client, privateKey);
@@ -66,14 +79,13 @@ async function main(): Promise<void> {
   };
   let stopAfterLog = false;
   let completedIterations = 0;
+  let retryableAttempts = 0;
   let iterationId = 0;
   for (;;) {
-    await sleep(randomSleepIntervalMs(sleepIntervalMs));
-
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    const executionLog: Record<string, any> = {};
+    const executionLog: Record<string, unknown> = {};
     const startTime = new Date();
     let stopAfterIteration = false;
+    let retryableAttempt = false;
     executionLog.startTime = startTime.toLocaleString();
     iterationId += 1;
     events.emit(iterationId, "bot.iteration.started");
@@ -89,6 +101,7 @@ async function main(): Promise<void> {
         poolDeposits: stateDecision.poolDeposits,
         exchangeRatio: stateDecision.exchangeRatio,
         depositCapacity: stateDecision.depositCapacity,
+        fee: stateDecision.fee,
       });
 
       executionLog.balance = {
@@ -137,7 +150,7 @@ async function main(): Promise<void> {
             executionLog.txHash = txHash;
           },
           onLifecycle: (event) => {
-            for (const lifecycle of transactionLifecycleEvents(event, secrets)) {
+            for (const lifecycle of transactionLifecycleEvents(event)) {
               events.emit(iterationId, lifecycle.type, {
                 ...lifecycle.fields,
                 ...(event.type === "broadcasted"
@@ -149,18 +162,39 @@ async function main(): Promise<void> {
         });
       }
     } catch (error) {
-      stopAfterLog = handleLoopError(executionLog, error, secrets);
-      const failure = iterationFailureEventFields(error, secrets);
+      let failure = iterationFailureEventFields(error);
+      if (failure.retryable) {
+        retryableAttempt = true;
+        retryableAttempts += 1;
+        failure = iterationFailureEventFields(error, {
+          retryableAttempts,
+          maxRetryableAttempts,
+        });
+      }
       events.emit(iterationId, "bot.iteration.failed", failure);
       if (failure.retryable) {
-        logExecution(executionLog, startTime);
-        continue;
+        executionLog.error = failure.error;
+        if (failure.retryBudgetExhausted) {
+          executionLog.error = {
+            message: "Retryable bot error budget exhausted",
+            attempts: retryableAttempts,
+            maxRetryableAttempts,
+            lastError: failure.error,
+          };
+          process.exitCode = STOP_EXIT_CODE;
+          stopAfterLog = true;
+        }
+      } else {
+        stopAfterLog = handleLoopError(executionLog, error);
       }
     }
 
-    const completion = completeTerminalIteration(completedIterations, maxIterations);
-    completedIterations = completion.completedIterations;
-    stopAfterIteration = completion.shouldStop;
+    if (!retryableAttempt) {
+      retryableAttempts = 0;
+      const completion = completeTerminalIteration(completedIterations, maxIterations);
+      completedIterations = completion.completedIterations;
+      stopAfterIteration = completion.shouldStop;
+    }
 
     logExecution(executionLog, startTime);
     if (stopAfterLog) {
@@ -169,6 +203,7 @@ async function main(): Promise<void> {
     if (stopAfterIteration) {
       return;
     }
+    await sleep(randomSleepIntervalMs(sleepIntervalMs));
   }
 }
 
@@ -187,20 +222,62 @@ export function completeTerminalIteration(
   };
 }
 
-export function iterationFailureEventFields(error: unknown, secrets: SecretRedactionContext = {}): {
+export function reachedMaxRetryableAttempts(
+  retryableAttempts: number,
+  maxRetryableAttempts: number | undefined,
+): boolean {
+  return maxRetryableAttempts !== undefined && retryableAttempts >= maxRetryableAttempts;
+}
+
+export function iterationFailureEventFields(error: unknown): {
   error: Record<string, unknown> | string;
   retryable: boolean;
   terminal: boolean;
+  retryableAttempts?: number;
+  maxRetryableAttempts?: number;
+  retryBudgetExhausted?: boolean;
+};
+export function iterationFailureEventFields(
+  error: unknown,
+  retryBudget: { retryableAttempts: number; maxRetryableAttempts: number | undefined },
+): {
+  error: Record<string, unknown> | string;
+  retryable: boolean;
+  terminal: boolean;
+  retryableAttempts: number;
+  maxRetryableAttempts?: number;
+  retryBudgetExhausted: boolean;
+};
+export function iterationFailureEventFields(
+  error: unknown,
+  retryBudget?: { retryableAttempts: number; maxRetryableAttempts: number | undefined },
+): {
+  error: Record<string, unknown> | string;
+  retryable: boolean;
+  terminal: boolean;
+  retryableAttempts?: number;
+  maxRetryableAttempts?: number;
+  retryBudgetExhausted?: boolean;
 } {
   const retryable = isRetryableBotError(error);
+  const retryBudgetExhausted = retryable && retryBudget !== undefined &&
+    reachedMaxRetryableAttempts(
+      retryBudget.retryableAttempts,
+      retryBudget.maxRetryableAttempts,
+    );
   return {
-    error: errorSummary(error, secrets),
+    error: errorSummary(error, { includeStack: !retryable }),
     retryable,
-    terminal: !retryable,
+    terminal: !retryable || retryBudgetExhausted,
+    ...(retryBudget === undefined ? {} : {
+      retryableAttempts: retryBudget.retryableAttempts,
+      ...(retryBudget.maxRetryableAttempts === undefined ? {} : { maxRetryableAttempts: retryBudget.maxRetryableAttempts }),
+      retryBudgetExhausted,
+    }),
   };
 }
 
-async function readBotState(runtime: Runtime): Promise<BotState> {
+export async function readBotState(runtime: Runtime): Promise<BotState> {
   const accountLocks = await signerAccountLocks(runtime.signer, runtime.primaryLock);
   const { system, user, account } = await runtime.sdk.getL1AccountState(
     runtime.client,
@@ -257,10 +334,10 @@ function outPointKey(outPoint: ccc.OutPoint): string {
 const fmtCkb = formatCkb;
 
 export function isRetryableBotError(error: unknown): boolean {
-  return error instanceof Error && (
-    error.message.includes("L1 state scan crossed chain tip") ||
-    (error instanceof TypeError && error.message === "fetch failed")
-  );
+  return (error instanceof Error && (
+    error.message === "L1 state scan crossed chain tip; retry with a fresh state" ||
+    isRetryableRpcTransportError(error)
+  )) || isRetryableCkbStateRaceError(error);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -150,7 +150,7 @@ async function main(): Promise<void> {
             executionLog.txHash = txHash;
           },
           onLifecycle: (event) => {
-            for (const lifecycle of transactionLifecycleEvents(event)) {
+            for (const lifecycle of transactionLifecycleEvents(event, isRetryableBotError)) {
               events.emit(iterationId, lifecycle.type, {
                 ...lifecycle.fields,
                 ...(event.type === "broadcasted"

--- a/apps/bot/src/observability.test.ts
+++ b/apps/bot/src/observability.test.ts
@@ -145,6 +145,8 @@ describe("bot observability", () => {
       evidence: {
         toJSON: (): Record<string, string> => ({ ignored: "custom serializer" }),
         circular,
+        observedAt: new Date("2026-01-02T03:04:05.006Z"),
+        invalidAt: new Date(Number.NaN),
       },
     });
 
@@ -152,6 +154,8 @@ describe("bot observability", () => {
       evidence: {
         toJSON: "[Unsupported log value]",
         circular: { label: "root", self: "[Circular]" },
+        observedAt: "2026-01-02T03:04:05.006Z",
+        invalidAt: null,
       },
     });
   });

--- a/apps/bot/src/observability.test.ts
+++ b/apps/bot/src/observability.test.ts
@@ -426,12 +426,12 @@ describe("bot observability", () => {
     expect(nested.publicReason).toBe("visible evidence");
   });
 
-  it("marks pre-broadcast transport and CKB state-race failures retryable", () => {
+  it("uses the caller-owned retry classifier for pre-broadcast failures", () => {
     const transportEvents = transactionLifecycleEvents({
       type: "pre_broadcast_failed",
       elapsedMs: 12,
       error: new TypeError("fetch failed"),
-    });
+    }, () => true);
     const rbfEvents = transactionLifecycleEvents({
       type: "pre_broadcast_failed",
       elapsedMs: 12,
@@ -441,7 +441,12 @@ describe("bot observability", () => {
         currentFee: 11795n,
         leastFee: 12326n,
       }),
-    });
+    }, () => true);
+    const terminalEvents = transactionLifecycleEvents({
+      type: "pre_broadcast_failed",
+      elapsedMs: 12,
+      error: new Error("deterministic failure"),
+    }, () => false);
 
     expect(transportEvents).toMatchObject([{
       type: "bot.transaction.failed",
@@ -469,6 +474,16 @@ describe("bot observability", () => {
       },
     }]);
     expect(rbfEvents[0]?.fields.error).not.toHaveProperty("stack");
+    expect(terminalEvents).toMatchObject([{
+      type: "bot.transaction.failed",
+      fields: {
+        phase: "pre_broadcast",
+        outcome: "pre_broadcast_failed",
+        retryable: false,
+        terminal: true,
+      },
+    }]);
+    expect(terminalEvents[0]?.fields.error).toHaveProperty("stack");
   });
 
   it("summarizes thrown objects with JSON-safe debugging details preserved", () => {

--- a/apps/bot/src/observability.test.ts
+++ b/apps/bot/src/observability.test.ts
@@ -24,6 +24,59 @@ const noActions: BotActions = {
 };
 
 describe("bot observability", () => {
+  it("keeps stack traces by default but can summarize retryable errors", () => {
+    const error = new Error("scan raced chain tip");
+    const summary = errorSummary(error);
+
+    expect(summary).toMatchObject({
+      name: "Error",
+      message: "scan raced chain tip",
+    });
+    expect(typeof summary).toBe("object");
+    expect(summary).not.toBeNull();
+    expect((summary as Record<string, unknown>)["stack"]).toContain("scan raced chain tip");
+    expect(errorSummary(error, { includeStack: false })).toEqual({
+      name: "Error",
+      message: "scan raced chain tip",
+    });
+  });
+
+  it("preserves public CKB RPC error fields from Error objects", () => {
+    const rbfError = Object.assign(new Error("Client request error PoolRejectedRBF"), {
+      code: -1111,
+      data: "RBFRejected(\"Tx's current fee is 11795, expect it to >= 12326 to replace old txs\")",
+      currentFee: 11795n,
+      leastFee: 12326n,
+    });
+    const resolveError = Object.assign(new Error("Client request error TransactionFailedToResolve"), {
+      code: -301,
+      data: `Resolve(Unknown(OutPoint(0x${"11".repeat(32)}00000000)))`,
+      outPoint: {
+        txHash: `0x${"11".repeat(32)}`,
+        index: 0n,
+      },
+    });
+
+    expect(errorSummary(rbfError, { includeStack: false })).toEqual({
+      name: "Error",
+      message: "Client request error PoolRejectedRBF",
+      code: -1111,
+      data: "RBFRejected(\"Tx's current fee is 11795, expect it to >= 12326 to replace old txs\")",
+      currentFee: "11795",
+      leastFee: "12326",
+    });
+    expect(errorSummary(resolveError, { includeStack: false })).toEqual({
+      name: "Error",
+      message: "Client request error TransactionFailedToResolve",
+      code: -301,
+      data: `Resolve(Unknown(OutPoint(0x${"11".repeat(32)}00000000)))`,
+      outPoint: {
+        txHash: `0x${"11".repeat(32)}`,
+        index: "0",
+      },
+    });
+  });
+
   it("emits one structured JSON-compatible event", () => {
     const written: unknown[] = [];
     const emitter = new BotEventEmitter({
@@ -37,12 +90,17 @@ describe("bot observability", () => {
     const event = emitter.emit(7, "bot.decision.skipped", {
       reason: "no_actions",
       amount: 9007199254740993n,
-      witnesses: ["0xabc"],
-      witness: "0xabc",
-      output_data: "0xabc",
+      witnesses: ["0x" + "11".repeat(80)],
+      witness: "0x" + "22".repeat(80),
+      output_data: "0x" + "33".repeat(80),
       transactionShape: { witnesses: 1 },
+      txHash: `0x${"44".repeat(32)}`,
+      tx: { inputs: [], outputs: [], witnesses: [] },
       lock: { codeHash: "0xabc", hashType: "type", args: "0xdef" },
+      cell: { cellOutput: { lock: { codeHash: "0xabc", hashType: "type", args: "0xdef" } } },
       env: "testnet",
+      environment: { BOT_CONFIG_FILE: "/run/credentials/config.json" },
+      config: { chain: "testnet" },
     });
 
     expect(written).toHaveLength(1);
@@ -56,14 +114,46 @@ describe("bot observability", () => {
       type: "bot.decision.skipped",
       reason: "no_actions",
       amount: "9007199254740993",
-      witnesses: ["0xabc"],
-      witness: "0xabc",
-      output_data: "0xabc",
+      witnesses: ["0x" + "11".repeat(80)],
+      witness: "0x" + "22".repeat(80),
+      output_data: "0x" + "33".repeat(80),
       transactionShape: { witnesses: 1 },
+      tx: { inputs: [], outputs: [], witnesses: [] },
       lock: { codeHash: "0xabc", hashType: "type", args: "0xdef" },
+      cell: { cellOutput: { lock: { codeHash: "0xabc", hashType: "type", args: "0xdef" } } },
       env: "testnet",
+      environment: { BOT_CONFIG_FILE: "/run/credentials/config.json" },
+      config: { chain: "testnet" },
     });
+    expect((written[0] as Record<string, unknown>).txHash).toBe(`0x${"44".repeat(32)}`);
     expect(typeof (written[0] as { timestamp: unknown }).timestamp).toBe("string");
+  });
+
+  it("emits functions and circular values as JSON-safe fields", () => {
+    const written: unknown[] = [];
+    const emitter = new BotEventEmitter({
+      chain: "testnet",
+      runId: "run-1",
+      write: (event): void => {
+        written.push(event);
+      },
+    });
+    const circular: Record<string, unknown> = { label: "root" };
+    circular.self = circular;
+
+    emitter.emit(7, "bot.decision.skipped", {
+      evidence: {
+        toJSON: (): Record<string, string> => ({ ignored: "custom serializer" }),
+        circular,
+      },
+    });
+
+    expect(written[0]).toMatchObject({
+      evidence: {
+        toJSON: "[Unsupported log value]",
+        circular: { label: "root", self: "[Circular]" },
+      },
+    });
   });
 
   it("maps terminal lifecycle callbacks into confirmation and failure events", () => {
@@ -78,20 +168,26 @@ describe("bot observability", () => {
         type: "bot.transaction.confirmation",
         fields: {
           txHash: "0x01",
+          phase: "confirmation",
           status: "unknown",
           checks: 3,
           elapsedMs: 20,
           outcome: "timeout_after_broadcast",
+          retryable: false,
+          terminal: true,
         },
       },
       {
         type: "bot.transaction.failed",
         fields: {
           txHash: "0x01",
+          phase: "confirmation",
           status: "unknown",
           checks: 3,
           elapsedMs: 20,
           outcome: "timeout_after_broadcast",
+          retryable: false,
+          terminal: true,
         },
       },
     ]);
@@ -178,7 +274,95 @@ describe("bot observability", () => {
     expect((written[0] as { timestamp: string }).timestamp).not.toBe("not-iso");
   });
 
-  it("preserves public error messages in structured error summaries", () => {
+  it("emits public chain preflight evidence", () => {
+    const written: unknown[] = [];
+    const emitter = new BotEventEmitter({
+      chain: "testnet",
+      runId: "run-1",
+      write: (event): void => {
+        written.push(event);
+      },
+    });
+    const genesisHash = `0x${"11".repeat(32)}`;
+    const tipHash = `0x${"22".repeat(32)}`;
+
+    emitter.emit(0, "bot.chain.preflight", {
+      rpcConfigured: true,
+      expected: {
+        chain: "testnet",
+        networkName: "ckb_testnet",
+        genesisHash,
+        genesisMessage: "aggron-v4",
+        genesisSource: "test fixture",
+        addressPrefix: "ckt",
+      },
+      observed: {
+        genesisHash,
+        addressPrefix: "ckt",
+        tip: {
+          hash: tipHash,
+          number: 123n,
+          timestamp: 456n,
+        },
+      },
+      matches: {
+        genesisHash: true,
+        addressPrefix: true,
+      },
+    });
+
+    expect(written[0]).toMatchObject({
+      type: "bot.chain.preflight",
+      rpcConfigured: true,
+      expected: { chain: "testnet", genesisHash, addressPrefix: "ckt" },
+      observed: {
+        genesisHash,
+        addressPrefix: "ckt",
+        tip: { hash: tipHash, number: "123", timestamp: "456" },
+      },
+      matches: { genesisHash: true, addressPrefix: true },
+    });
+  });
+
+  it("emits run context without private key material", () => {
+    const written: unknown[] = [];
+    const emitter = new BotEventEmitter({
+      chain: "testnet",
+      runId: "run-1",
+      write: (event): void => {
+        written.push(event);
+      },
+    });
+
+    emitter.emit(0, "bot.run.started", {
+      maxIterations: 1,
+      bounded: true,
+      runtime: {
+        maxIterations: 1,
+        bounded: true,
+        sleepIntervalMs: 60000,
+        rpcConfigured: true,
+      },
+      config: { chain: "testnet" },
+      rpcHost: "testnet.example",
+    });
+
+    expect(written[0]).toMatchObject({
+      type: "bot.run.started",
+      maxIterations: 1,
+      bounded: true,
+      runtime: {
+        maxIterations: 1,
+        bounded: true,
+        sleepIntervalMs: 60000,
+        rpcConfigured: true,
+      },
+      config: { chain: "testnet" },
+      rpcHost: "testnet.example",
+    });
+  });
+
+  it("preserves transaction-shaped error messages in structured error summaries", () => {
     const error = new Error("failed with witness 0x" + "22".repeat(80));
 
     const summary = errorSummary(error) as Record<string, unknown>;
@@ -186,6 +370,14 @@ describe("bot observability", () => {
     expect(summary.name).toBe("Error");
     expect(summary.message).toBe("failed with witness 0x" + "22".repeat(80));
     expect(summary.stack).toContain("failed with witness");
+  });
+
+  it("preserves serialized transaction-shaped error messages", () => {
+    const error = new Error(`failed {"witnesses":["0x${"22".repeat(80)}"],"inputs":[]}`);
+
+    const summary = errorSummary(error) as Record<string, unknown>;
+
+    expect(summary.message).toBe(`failed {"witnesses":["0x${"22".repeat(80)}"],"inputs":[]}`);
   });
 
   it("preserves nested error causes in structured error summaries", () => {
@@ -200,68 +392,92 @@ describe("bot observability", () => {
     });
   });
 
-  it("redacts runtime secrets in structured error summaries", () => {
-    const privateKey = `0x${"11".repeat(32)}`;
-    const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
-    const cause = new Error(`inner ${privateKey} ${rpcUrl}`);
-    const error = new Error(`outer ${privateKey} ${rpcUrl}`, { cause });
-    error.stack = `outer stack ${privateKey} ${rpcUrl}`;
-    cause.stack = `inner stack ${privateKey} ${rpcUrl}`;
-
-    const summary = errorSummary(error, { privateKey, rpcUrl }) as Record<string, unknown>;
-    const serialized = JSON.stringify(summary);
-
-    expect(serialized).not.toContain(privateKey);
-    expect(serialized).not.toContain("user:pass");
-    expect(serialized).not.toContain("secret");
-    expect(serialized).toContain("<redacted-private-key>");
-    expect(serialized).toContain("https://redacted:redacted@testnet.example/...?token=redacted");
-  });
-
-  it("redacts runtime secrets in structured object error summaries", () => {
-    const privateKey = `0x${"11".repeat(32)}`;
-    const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
+  it("preserves public RPC debugging data in structured object error summaries", () => {
+    const rpcUrl = "https://testnet.example/rpc/path";
 
     const summary = errorSummary({
-      message: `object ${privateKey}`,
+      message: `object ${rpcUrl}`,
       rpcUrl,
       amount: 9007199254740993n,
-    }, { privateKey, rpcUrl }) as Record<string, unknown>;
+    }) as Record<string, unknown>;
     const serialized = JSON.stringify(summary);
 
-    expect(serialized).not.toContain(privateKey);
-    expect(serialized).not.toContain("user:pass");
-    expect(serialized).not.toContain("secret");
-    expect(serialized).toContain("<redacted-private-key>");
-    expect(serialized).toContain("https://redacted:redacted@testnet.example/...?token=redacted");
+    expect(serialized).toContain(rpcUrl);
+    expect((summary.details as Record<string, unknown>).rpcUrl).toBe(rpcUrl);
   });
 
-  it("redacts runtime secrets in transaction lifecycle errors", () => {
-    const privateKey = `0x${"11".repeat(32)}`;
-    const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
-    const error = new Error(`lifecycle ${privateKey} ${rpcUrl}`);
+  it("preserves public nested object error fields", () => {
+    const rpcUrl = "https://testnet.example/rpc/path";
 
-    const events = transactionLifecycleEvents({
+    const summary = errorSummary({
+      message: `failed ${rpcUrl}`,
+      nested: {
+        publicReason: "visible evidence",
+      },
+    }) as Record<string, unknown>;
+    const details = summary.details as Record<string, unknown>;
+    const nested = details.nested as Record<string, unknown>;
+
+    expect(details.message).toBe(`failed ${rpcUrl}`);
+    expect(nested.publicReason).toBe("visible evidence");
+  });
+
+  it("marks pre-broadcast transport and CKB state-race failures retryable", () => {
+    const transportEvents = transactionLifecycleEvents({
       type: "pre_broadcast_failed",
       elapsedMs: 12,
-      error,
-    }, { privateKey, rpcUrl });
-    const serialized = JSON.stringify(events);
+      error: new TypeError("fetch failed"),
+    });
+    const rbfEvents = transactionLifecycleEvents({
+      type: "pre_broadcast_failed",
+      elapsedMs: 12,
+      error: Object.assign(new Error("Client request error PoolRejectedRBF"), {
+        code: -1111,
+        data: "RBFRejected(\"Tx's current fee is 11795, expect it to >= 12326 to replace old txs\")",
+        currentFee: 11795n,
+        leastFee: 12326n,
+      }),
+    });
 
-    expect(serialized).not.toContain(privateKey);
-    expect(serialized).not.toContain("user:pass");
-    expect(serialized).not.toContain("secret");
-    expect(serialized).toContain("<redacted-private-key>");
-    expect(serialized).toContain("https://redacted:redacted@testnet.example/...?token=redacted");
+    expect(transportEvents).toMatchObject([{
+      type: "bot.transaction.failed",
+      fields: {
+        phase: "pre_broadcast",
+        outcome: "pre_broadcast_failed",
+        retryable: true,
+        terminal: false,
+      },
+    }]);
+    expect(transportEvents[0]?.fields.error).not.toHaveProperty("stack");
+    expect(rbfEvents).toMatchObject([{
+      type: "bot.transaction.failed",
+      fields: {
+        phase: "pre_broadcast",
+        outcome: "pre_broadcast_failed",
+        retryable: true,
+        terminal: false,
+        error: {
+          code: -1111,
+          data: "RBFRejected(\"Tx's current fee is 11795, expect it to >= 12326 to replace old txs\")",
+          currentFee: "11795",
+          leastFee: "12326",
+        },
+      },
+    }]);
+    expect(rbfEvents[0]?.fields.error).not.toHaveProperty("stack");
   });
 
-  it("summarizes thrown objects with JSON-safe details", () => {
+  it("summarizes thrown objects with JSON-safe debugging details preserved", () => {
     const summary = errorSummary({
       code: "RPC_FAILURE",
       amount: 9007199254740993n,
       message: "failed with public evidence",
       lock: { codeHash: "0xabc", hashType: "type", args: "0xdef" },
+      cell: { cellOutput: { lock: { codeHash: "0xabc", hashType: "type", args: "0xdef" } } },
       witnesses: ["0x" + "22".repeat(80)],
+      signedTx: "0x" + "33".repeat(80),
+      env: { BOT_CONFIG_FILE: "/run/credentials/config.json" },
+      config: { chain: "testnet" },
     }) as Record<string, unknown>;
 
     expect(summary).toEqual({
@@ -271,7 +487,34 @@ describe("bot observability", () => {
         amount: "9007199254740993",
         message: "failed with public evidence",
         lock: { codeHash: "0xabc", hashType: "type", args: "0xdef" },
+        cell: { cellOutput: { lock: { codeHash: "0xabc", hashType: "type", args: "0xdef" } } },
         witnesses: ["0x" + "22".repeat(80)],
+        signedTx: "0x" + "33".repeat(80),
+        env: { BOT_CONFIG_FILE: "/run/credentials/config.json" },
+        config: { chain: "testnet" },
+      },
+    });
+  });
+
+  it("preserves transaction-shaped details from nested object causes", () => {
+    const summary = errorSummary(new Error("outer", {
+      cause: {
+        message: "inner public evidence",
+        inputs: [{}],
+        outputsData: ["0x" + "22".repeat(80)],
+        cellDeps: [{}],
+        headerDeps: [{}],
+      },
+    })) as Record<string, unknown>;
+
+    expect(summary.cause).toEqual({
+      message: "Non-Error object",
+      details: {
+        message: "inner public evidence",
+        inputs: [{}],
+        outputsData: ["0x" + "22".repeat(80)],
+        cellDeps: [{}],
+        headerDeps: [{}],
       },
     });
   });
@@ -301,11 +544,12 @@ describe("bot observability", () => {
         totalEquivalentCkb: 0n,
         totalEquivalentIckb: 0n,
         minimumCkbCapital: 0n,
+        spendableCkb: 0n,
       },
       orders: { marketCount: 0, userCount: 0, receiptCount: 0 },
       withdrawals: { readyCount: 0, pendingCount: 0 },
       poolDeposits: { readyCount: 0, nearReadyCount: 0, futureCount: 0 },
-      match: { partialCount: 0, ckbDelta: 0n, udtDelta: 0n },
+      match: { reason: "no_market_orders", partialCount: 0, ckbDelta: 0n, udtDelta: 0n },
       rebalance: {
         kind: "none",
         reason: "target_ickb_not_exceeded",
@@ -390,12 +634,14 @@ describe("bot observability", () => {
         totalEquivalentCkb: 0n,
         totalEquivalentIckb: 0n,
         minimumCkbCapital: 1n,
+        spendableCkb: 0n,
       },
       orders: { marketCount: 0, userCount: 0, receiptCount: 0 },
       withdrawals: { readyCount: 0, pendingCount: 0 },
       poolDeposits: { readyCount: 0, nearReadyCount: 0, futureCount: 0 },
       exchangeRatio: { ckbScale: 1n, udtScale: 1n },
       depositCapacity: 0n,
+      fee: { feeRate: 1n },
     };
 
     const skip = lowCapitalSkipDecision(state);
@@ -404,6 +650,7 @@ describe("bot observability", () => {
       reason: "capital_below_minimum",
       actions: noActions,
       state,
+      deficit: 1n,
     });
     expect(skip).not.toHaveProperty("decision");
   });

--- a/apps/bot/src/observability.test.ts
+++ b/apps/bot/src/observability.test.ts
@@ -396,6 +396,22 @@ describe("bot observability", () => {
     });
   });
 
+  it("tracks circular references in custom Error properties", () => {
+    const details: Record<string, unknown> = {};
+    const error = Object.assign(new Error("outer public failure"), {
+      details,
+    });
+    error.details.self = error;
+
+    const summary = errorSummary(error, { includeStack: false }) as Record<string, unknown>;
+
+    expect(summary).toEqual({
+      name: "Error",
+      message: "outer public failure",
+      details: { self: "[Circular]" },
+    });
+  });
+
   it("preserves public RPC debugging data in structured object error summaries", () => {
     const rpcUrl = "https://testnet.example/rpc/path";
 

--- a/apps/bot/src/observability.ts
+++ b/apps/bot/src/observability.ts
@@ -335,6 +335,9 @@ function logValue(value: unknown, seen: Set<unknown>): unknown {
   if (typeof value !== "object" || value === null) {
     return value;
   }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
   if (seen.has(value)) {
     return "[Circular]";
   }

--- a/apps/bot/src/observability.ts
+++ b/apps/bot/src/observability.ts
@@ -1,7 +1,5 @@
 import { type ccc } from "@ckb-ccc/core";
 import {
-  isRetryableCkbStateRaceError,
-  isRetryableRpcTransportError,
   jsonLogReplacer,
   writeJsonLine,
   type SupportedChain,
@@ -123,6 +121,7 @@ export function transactionSummary(
 
 export function transactionLifecycleEvents(
   event: SendAndWaitForCommitEvent,
+  isRetryableError: (error: unknown) => boolean = (): boolean => false,
 ): Array<{
   type: "bot.transaction.sent" | "bot.transaction.confirmation" | "bot.transaction.committed" | "bot.transaction.failed";
   fields: Record<string, unknown>;
@@ -199,8 +198,7 @@ export function transactionLifecycleEvents(
       ];
     case "pre_broadcast_failed":
       {
-        const retryable = isRetryableRpcTransportError(event.error) ||
-          isRetryableCkbStateRaceError(event.error);
+        const retryable = isRetryableError(event.error);
         return [{
           type: "bot.transaction.failed",
           fields: {

--- a/apps/bot/src/observability.ts
+++ b/apps/bot/src/observability.ts
@@ -1,9 +1,9 @@
 import { type ccc } from "@ckb-ccc/core";
 import {
+  isRetryableCkbStateRaceError,
+  isRetryableRpcTransportError,
   jsonLogReplacer,
-  redactSecretText,
   writeJsonLine,
-  type SecretRedactionContext,
   type SupportedChain,
 } from "@ickb/node-utils";
 import { type SendAndWaitForCommitEvent } from "@ickb/sdk";
@@ -19,6 +19,7 @@ const BOT_EVENT_VERSION = 1;
 
 export type BotEventType =
   | "bot.run.started"
+  | "bot.chain.preflight"
   | "bot.iteration.started"
   | "bot.state.read"
   | "bot.match.evaluated"
@@ -122,7 +123,6 @@ export function transactionSummary(
 
 export function transactionLifecycleEvents(
   event: SendAndWaitForCommitEvent,
-  secrets: SecretRedactionContext = {},
 ): Array<{
   type: "bot.transaction.sent" | "bot.transaction.confirmation" | "bot.transaction.committed" | "bot.transaction.failed";
   fields: Record<string, unknown>;
@@ -131,17 +131,27 @@ export function transactionLifecycleEvents(
     case "broadcasted":
       return [{
         type: "bot.transaction.sent",
-        fields: { txHash: event.txHash, elapsedMs: event.elapsedMs },
+        fields: {
+          txHash: event.txHash,
+          phase: "broadcast",
+          outcome: "broadcasted",
+          elapsedMs: event.elapsedMs,
+        },
       }];
     case "committed":
       return [
         {
           type: "bot.transaction.confirmation",
-          fields: { ...confirmationFields(event, secrets), outcome: "committed" },
+          fields: {
+            ...confirmationFields(event),
+            outcome: "committed",
+            retryable: false,
+            terminal: true,
+          },
         },
         {
           type: "bot.transaction.committed",
-          fields: confirmationFields(event, secrets),
+          fields: { ...confirmationFields(event), outcome: "committed" },
         },
       ];
     case "timeout_after_broadcast":
@@ -150,15 +160,19 @@ export function transactionLifecycleEvents(
         {
           type: "bot.transaction.confirmation",
           fields: {
-            ...confirmationFields(event, secrets),
+            ...confirmationFields(event),
             outcome: event.type,
+            retryable: false,
+            terminal: true,
           },
         },
         {
           type: "bot.transaction.failed",
           fields: {
-            ...confirmationFields(event, secrets),
+            ...confirmationFields(event),
             outcome: event.type,
+            retryable: false,
+            terminal: true,
           },
         },
       ];
@@ -167,27 +181,38 @@ export function transactionLifecycleEvents(
         {
           type: "bot.transaction.confirmation",
           fields: {
-            ...confirmationFields(event, secrets),
+            ...confirmationFields(event),
             outcome: "terminal_rejection",
+            retryable: false,
+            terminal: true,
           },
         },
         {
           type: "bot.transaction.failed",
           fields: {
-            ...confirmationFields(event, secrets),
+            ...confirmationFields(event),
             outcome: "terminal_rejection",
+            retryable: false,
+            terminal: true,
           },
         },
       ];
     case "pre_broadcast_failed":
-      return [{
-        type: "bot.transaction.failed",
-        fields: {
-          phase: "pre_broadcast",
-          elapsedMs: event.elapsedMs,
-          error: errorSummary(event.error, secrets),
-        },
-      }];
+      {
+        const retryable = isRetryableRpcTransportError(event.error) ||
+          isRetryableCkbStateRaceError(event.error);
+        return [{
+          type: "bot.transaction.failed",
+          fields: {
+            phase: "pre_broadcast",
+            outcome: "pre_broadcast_failed",
+            elapsedMs: event.elapsedMs,
+            error: errorSummary(event.error, { includeStack: !retryable }),
+            retryable,
+            terminal: !retryable,
+          },
+        }];
+      }
   }
 }
 
@@ -197,7 +222,9 @@ export function lowCapitalSkipDecision(
   reason: BotDecisionSkipReason;
   actions: BotActions;
   state: BotStateSummary;
+  deficit: bigint;
 } {
+  const deficit = summary.balances.minimumCkbCapital - summary.balances.totalEquivalentCkb;
   return {
     reason: "capital_below_minimum",
     actions: {
@@ -209,20 +236,21 @@ export function lowCapitalSkipDecision(
       withdrawals: 0,
     },
     state: summary,
+    deficit: deficit > 0n ? deficit : 0n,
   };
 }
 
 export function errorSummary(
   error: unknown,
-  secrets: SecretRedactionContext = {},
+  options: { includeStack?: boolean } = {},
 ): Record<string, unknown> | string {
-  return summarizeError(error, new Set<unknown>(), secrets);
+  return summarizeError(error, new Set<unknown>(), options.includeStack ?? true);
 }
 
 function summarizeError(
   error: unknown,
   seen: Set<unknown>,
-  secrets: SecretRedactionContext,
+  includeStack: boolean,
 ): Record<string, unknown> | string {
   if (error instanceof Error) {
     if (seen.has(error)) {
@@ -231,29 +259,26 @@ function summarizeError(
     seen.add(error);
 
     return {
+      ...errorOwnProperties(error),
       name: error.name,
-      message: redactSecretText(error.message, secrets),
-      ...(error.stack === undefined ? {} : { stack: redactSecretText(error.stack, secrets) }),
-      ...("txHash" in error ? { txHash: error.txHash } : {}),
-      ...("status" in error ? { status: error.status } : {}),
-      ...("isTimeout" in error ? { isTimeout: error.isTimeout } : {}),
-      ...("cause" in error ? { cause: summarizeError(error.cause, seen, secrets) } : {}),
+      message: logValue(error.message, seen),
+      ...(includeStack && error.stack !== undefined ? { stack: logValue(error.stack, seen) } : {}),
+      ...("txHash" in error ? { txHash: logValue(error.txHash, seen) } : {}),
+      ...("status" in error ? { status: logValue(error.status, seen) } : {}),
+      ...("isTimeout" in error ? { isTimeout: logValue(error.isTimeout, seen) } : {}),
+      ...("cause" in error ? { cause: summarizeError(error.cause, seen, includeStack) } : {}),
     };
   }
 
   if (typeof error === "object" && error !== null) {
-    try {
-      return {
-        message: "Non-Error object",
-        details: JSON.parse(redactSecretText(JSON.stringify(error, jsonLogReplacer), secrets)) as unknown,
-      };
-    } catch {
-      return { message: "Non-Error object (unserializable)" };
-    }
+    return {
+      message: "Non-Error object",
+      details: logValue(error, seen),
+    };
   }
 
   if (typeof error === "string") {
-    return redactSecretText(error, secrets);
+    return logValue(error, seen) as string;
   }
 
   if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
@@ -263,19 +288,67 @@ function summarizeError(
   return "Empty Error";
 }
 
+const ERROR_BUILTIN_KEYS = new Set(["name", "message", "stack", "cause"]);
+
+function errorOwnProperties(error: Error): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(error)) {
+    if (!ERROR_BUILTIN_KEYS.has(key)) {
+      properties[key] = value;
+    }
+  }
+  // CCC/CKB RPC errors carry retry evidence such as code, data, outPoint,
+  // currentFee, and leastFee as enumerable Error fields.
+  return logValue(properties, new Set<unknown>()) as Record<string, unknown>;
+}
+
 function confirmationFields(event: Extract<
   SendAndWaitForCommitEvent,
   { txHash: ccc.Hex; checks: number }
->, secrets: SecretRedactionContext = {}): Record<string, unknown> {
+>): Record<string, unknown> {
   return {
+    phase: "confirmation",
     txHash: event.txHash,
     status: event.status,
     checks: event.checks,
     elapsedMs: event.elapsedMs,
-    ...("error" in event ? { error: errorSummary(event.error, secrets) } : {}),
+    ...("error" in event ? { error: errorSummary(event.error) } : {}),
   };
 }
 
 function jsonSafeEventFields(fields: Record<string, unknown>): Record<string, unknown> {
-  return JSON.parse(JSON.stringify(fields, jsonLogReplacer)) as Record<string, unknown>;
+  return JSON.parse(JSON.stringify(logValue(fields, new Set<unknown>()), jsonLogReplacer)) as Record<string, unknown>;
+}
+
+const UNSUPPORTED_LOG_VALUE = "[Unsupported log value]";
+
+function logValue(value: unknown, seen: Set<unknown>): unknown {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "function") {
+    return UNSUPPORTED_LOG_VALUE;
+  }
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry) => logValue(entry, seen));
+    }
+    const logged: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      logged[key] = logValue(entry, seen);
+    }
+    return logged;
+  } finally {
+    seen.delete(value);
+  }
 }

--- a/apps/bot/src/observability.ts
+++ b/apps/bot/src/observability.ts
@@ -257,7 +257,7 @@ function summarizeError(
     seen.add(error);
 
     return {
-      ...errorOwnProperties(error),
+      ...errorOwnProperties(error, seen),
       name: error.name,
       message: logValue(error.message, seen),
       ...(includeStack && error.stack !== undefined ? { stack: logValue(error.stack, seen) } : {}),
@@ -288,7 +288,7 @@ function summarizeError(
 
 const ERROR_BUILTIN_KEYS = new Set(["name", "message", "stack", "cause"]);
 
-function errorOwnProperties(error: Error): Record<string, unknown> {
+function errorOwnProperties(error: Error, seen: Set<unknown>): Record<string, unknown> {
   const properties: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(error)) {
     if (!ERROR_BUILTIN_KEYS.has(key)) {
@@ -297,7 +297,7 @@ function errorOwnProperties(error: Error): Record<string, unknown> {
   }
   // CCC/CKB RPC errors carry retry evidence such as code, data, outPoint,
   // currentFee, and leastFee as enumerable Error fields.
-  return logValue(properties, new Set<unknown>()) as Record<string, unknown>;
+  return logValue(properties, seen) as Record<string, unknown>;
 }
 
 function confirmationFields(event: Extract<

--- a/apps/bot/src/runtime.ts
+++ b/apps/bot/src/runtime.ts
@@ -13,7 +13,7 @@ import {
   type OrderGroup,
 } from "@ickb/order";
 import { type getConfig, type IckbSdk, type SystemState } from "@ickb/sdk";
-import { postTransactionAccountPlainCkbBalance, type SupportedChain } from "@ickb/node-utils";
+import { accountPlainCkbBalance, postTransactionAccountPlainCkbBalance, type SupportedChain } from "@ickb/node-utils";
 import { collectCompleteScan, defaultFindCellsLimit } from "@ickb/utils";
 import {
   CKB_RESERVE,
@@ -285,6 +285,7 @@ export async function buildTransaction(
     feeRate: state.system.feeRate,
   });
   const fee = tx.estimateFee(state.system.feeRate);
+  const preTxCkbBalance = accountPlainCkbBalance(state.capacityCells, state.accountLocks);
   const postTxCkbBalance = postTransactionPlainCkbBalance(tx, state);
   decision = buildDecisionTranscript({
     state,
@@ -295,8 +296,21 @@ export async function buildTransaction(
     tx,
   });
   decision = { ...decision, fee: { ...decision.fee, estimated: fee } };
-  const worsensCkbReserve = actions.deposits > 0 || match.ckbDelta < 0n;
-  if (postTxCkbBalance < CKB_RESERVE && worsensCkbReserve) {
+  const preTxDeficit = maxBigInt(0n, CKB_RESERVE - preTxCkbBalance);
+  const postTxDeficit = maxBigInt(0n, CKB_RESERVE - postTxCkbBalance);
+  // The reserve is actual owned plain CKB, not projected CKB availability. Ready
+  // withdrawals and collectable orders can make projected CKB look healthy while
+  // the account still lacks plain cells for state rent and future fees.
+  //
+  // Most actions must not create or worsen a plain-CKB reserve deficit. The one
+  // intentional exception is an iCKB withdrawal request: it spends plain CKB for
+  // DAO withdrawal-cell rent now so the bot can recover CKB in a later completion
+  // transaction. Do not let CKB-spending matches or deposits hide behind that
+  // recovery exception.
+  const spendsReserveForWithdrawalRequest = actions.withdrawalRequests > 0 &&
+    actions.deposits === 0 &&
+    match.ckbDelta >= 0n;
+  if (postTxDeficit > preTxDeficit && !spendsReserveForWithdrawalRequest) {
     return skippedResult("post_tx_ckb_reserve", emptyActions(), {
       ...decision,
       actions: emptyActions(),
@@ -304,7 +318,7 @@ export async function buildTransaction(
       attemptedActions: actions,
       postTxCkbBalance,
       reserve: CKB_RESERVE,
-      deficit: CKB_RESERVE - postTxCkbBalance,
+      deficit: postTxDeficit,
     });
   }
 

--- a/apps/bot/src/runtime.ts
+++ b/apps/bot/src/runtime.ts
@@ -13,7 +13,7 @@ import {
   type OrderGroup,
 } from "@ickb/order";
 import { type getConfig, type IckbSdk, type SystemState } from "@ickb/sdk";
-import { type SupportedChain } from "@ickb/node-utils";
+import { postTransactionAccountPlainCkbBalance, type SupportedChain } from "@ickb/node-utils";
 import { collectCompleteScan, defaultFindCellsLimit } from "@ickb/utils";
 import {
   CKB_RESERVE,
@@ -75,6 +75,21 @@ export type BotDecisionSkipReason =
   | BuildTransactionSkipReason
   | "capital_below_minimum";
 
+export type BotMatchReason =
+  | "matched"
+  | "no_market_orders"
+  | "no_matchable_orders"
+  | "insufficient_allowance"
+  | "no_viable_candidates"
+  | "max_partials"
+  | "no_positive_gain";
+
+export type BotRebalanceReason =
+  | RebalanceNoopReason
+  | "low_ickb_balance"
+  | "future_pool_inventory"
+  | "excess_ickb_balance";
+
 export type BuildTransactionResult =
   | {
       kind: "built";
@@ -108,6 +123,7 @@ export interface BotDecisionTranscript {
     totalEquivalentCkb: bigint;
     totalEquivalentIckb: bigint;
     minimumCkbCapital: bigint;
+    spendableCkb: bigint;
   };
   orders: {
     marketCount: number;
@@ -124,6 +140,7 @@ export interface BotDecisionTranscript {
     futureCount: number;
   };
   match: {
+    reason: BotMatchReason;
     partialCount: number;
     ckbDelta: bigint;
     udtDelta: bigint;
@@ -132,7 +149,7 @@ export interface BotDecisionTranscript {
   };
   rebalance: {
     kind: RebalancePlan["kind"];
-    reason?: RebalanceNoopReason;
+    reason: BotRebalanceReason;
     depositQuantity?: number;
     withdrawalRequestCount?: number;
     requiredLiveDepositCount?: number;
@@ -164,6 +181,8 @@ export interface BotDecisionTranscript {
     matchValue?: bigint;
     postTxCkbBalance?: bigint;
     reserve?: bigint;
+    deficit?: bigint;
+    attemptedActions?: BotActions;
   };
 }
 
@@ -176,6 +195,7 @@ export type BotStateSummary = Pick<
   | "poolDeposits"
   | "exchangeRatio"
   | "depositCapacity"
+  | "fee"
 >;
 
 export type { SupportedChain };
@@ -275,11 +295,16 @@ export async function buildTransaction(
     tx,
   });
   decision = { ...decision, fee: { ...decision.fee, estimated: fee } };
-  const consumesCkbReserve = actions.deposits > 0 || match.ckbDelta < 0n;
-  if (postTxCkbBalance < CKB_RESERVE && consumesCkbReserve) {
-    return skippedResult("post_tx_ckb_reserve", actions, decision, {
+  const worsensCkbReserve = actions.deposits > 0 || match.ckbDelta < 0n;
+  if (postTxCkbBalance < CKB_RESERVE && worsensCkbReserve) {
+    return skippedResult("post_tx_ckb_reserve", emptyActions(), {
+      ...decision,
+      actions: emptyActions(),
+    }, {
+      attemptedActions: actions,
       postTxCkbBalance,
       reserve: CKB_RESERVE,
+      deficit: CKB_RESERVE - postTxCkbBalance,
     });
   }
 
@@ -324,6 +349,7 @@ export function summarizeBotState(state: BotState): BotStateSummary {
       totalEquivalentIckb: convert(true, state.totalCkbBalance, state.system.exchangeRatio) +
         state.availableIckbBalance,
       minimumCkbCapital: state.minCkbBalance,
+      spendableCkb: spendableCkb(state.availableCkbBalance),
     },
     orders: {
       marketCount: state.marketOrders.length,
@@ -344,6 +370,9 @@ export function summarizeBotState(state: BotState): BotStateSummary {
       udtScale: state.system.exchangeRatio.udtScale,
     },
     depositCapacity: state.depositCapacity,
+    fee: {
+      feeRate: state.system.feeRate,
+    },
   };
 }
 
@@ -410,6 +439,7 @@ function buildDecisionTranscript({
   return {
     ...summary,
     match: {
+      reason: matchReason(match, state),
       partialCount: match.partials.length,
       ckbDelta: match.ckbDelta,
       udtDelta: match.udtDelta,
@@ -432,7 +462,7 @@ function rebalanceSummary(
 ): BotDecisionTranscript["rebalance"] {
   return {
     kind: rebalance.kind,
-    ...(rebalance.kind === "none" ? { reason: rebalance.reason } : {}),
+    reason: rebalanceReason(rebalance),
     ...(rebalance.kind === "deposit" ? { depositQuantity: rebalance.quantity } : {}),
     ...(rebalance.kind === "withdraw"
       ? {
@@ -447,6 +477,55 @@ function rebalanceSummary(
   };
 }
 
+function matchReason(
+  match: Pick<Match, "partials" | "diagnostics">,
+  state: BotState,
+): BotMatchReason {
+  if (match.partials.length > 0) {
+    return "matched";
+  }
+  if (state.marketOrders.length === 0) {
+    return "no_market_orders";
+  }
+
+  const diagnostics = match.diagnostics;
+  if (diagnostics === undefined) {
+    return "no_viable_candidates";
+  }
+  if (
+    diagnostics.directions.ckbToUdt.matchableCount === 0 &&
+    diagnostics.directions.udtToCkb.matchableCount === 0
+  ) {
+    return "no_matchable_orders";
+  }
+  if (diagnostics.candidates.viable === 0) {
+    return diagnostics.candidates.rejected.insufficientCkbAllowance > 0 ||
+      diagnostics.candidates.rejected.insufficientUdtAllowance > 0
+      ? "insufficient_allowance"
+      : "no_viable_candidates";
+  }
+  if (diagnostics.candidates.rejected.maxPartials > 0 && diagnostics.candidates.positiveGain === 0) {
+    return "max_partials";
+  }
+  if (diagnostics.candidates.positiveGain === 0) {
+    return "no_positive_gain";
+  }
+  return "no_viable_candidates";
+}
+
+function rebalanceReason(rebalance: RebalancePlan): BotRebalanceReason {
+  switch (rebalance.kind) {
+    case "none":
+      return rebalance.reason;
+    case "deposit":
+      return rebalance.diagnostics === undefined
+        ? "low_ickb_balance"
+        : "future_pool_inventory";
+    case "withdraw":
+      return "excess_ickb_balance";
+  }
+}
+
 export function transactionShape(tx: ccc.Transaction): BotDecisionTranscript["transactionShape"] {
   return {
     inputs: tx.inputs.length,
@@ -458,29 +537,14 @@ export function transactionShape(tx: ccc.Transaction): BotDecisionTranscript["tr
 }
 
 export function postTransactionPlainCkbBalance(tx: ccc.Transaction, state: BotState): bigint {
-  const accountLockHexes = new Set(state.accountLocks.map((lock) => lock.toHex()));
-  const spentOutPoints = new Set(tx.inputs.map((input) => input.previousOutput.toHex()));
-  const unspentCapacity = state.capacityCells.reduce(
-    (total, cell) =>
-      spentOutPoints.has(cell.outPoint.toHex()) ||
-      !isAccountPlainCapacityOutput(cell.cellOutput, cell.outputData, accountLockHexes)
-        ? total
-        : total + cell.cellOutput.capacity,
-    0n,
-  );
-  const outputCapacity = tx.outputs.reduce(
-    (total, output, index) => total + (isAccountPlainCapacityOutput(output, tx.outputsData[index], accountLockHexes) ? output.capacity : 0n),
-    0n,
-  );
-
-  return unspentCapacity + outputCapacity;
+  return postTransactionAccountPlainCkbBalance(tx, state.capacityCells, state.accountLocks);
 }
 
 function skippedResult(
   reason: BuildTransactionSkipReason,
   actions: BotActions,
   decision: BotDecisionTranscript,
-  details?: { fee?: bigint; matchValue?: bigint; postTxCkbBalance?: bigint; reserve?: bigint },
+  details?: { fee?: bigint; matchValue?: bigint; postTxCkbBalance?: bigint; reserve?: bigint; deficit?: bigint; attemptedActions?: BotActions },
 ): BuildTransactionResult {
   return {
     kind: "skipped",
@@ -496,6 +560,17 @@ function skippedResult(
   };
 }
 
+function emptyActions(): BotActions {
+  return {
+    collectedOrders: 0,
+    completedDeposits: 0,
+    matchedOrders: 0,
+    deposits: 0,
+    withdrawalRequests: 0,
+    withdrawals: 0,
+  };
+}
+
 function actionTotal(actions: BotActions): number {
   return actions.collectedOrders +
     actions.completedDeposits +
@@ -507,10 +582,6 @@ function actionTotal(actions: BotActions): number {
 
 function spendableCkb(availableCkbBalance: bigint): bigint {
   return maxBigInt(0n, availableCkbBalance - CKB_RESERVE);
-}
-
-function isAccountPlainCapacityOutput(output: ccc.CellOutput, outputData: string | undefined, accountLockHexes: Set<string>): boolean {
-  return output.type === undefined && (outputData ?? "0x") === "0x" && accountLockHexes.has(output.lock.toHex());
 }
 
 function maxBigInt(left: bigint, right: bigint): bigint {

--- a/apps/tester/src/index.test.ts
+++ b/apps/tester/src/index.test.ts
@@ -81,8 +81,9 @@ describe("readTesterScenario", () => {
 });
 
 describe("tester private key output boundary", () => {
-  it("does not leak the configured canary key across representative crash output", async () => {
+  it("does not leak configured canary secrets across representative crash output", async () => {
     const privateKey = `0x${"42".repeat(32)}`;
+    const rpcUrl = "https://user:pass@testnet.example/path?token=secret";
     const dir = await mkdtemp(join(tmpdir(), "ickb-tester-private-key-boundary-"));
     const output: string[] = [];
     const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
@@ -94,6 +95,7 @@ describe("tester private key output boundary", () => {
       await writeFile(configPath, JSON.stringify({
         chain: "testnet",
         privateKey,
+        rpcUrl,
         sleepIntervalSeconds: 10,
         maxIterations: 1,
       }), { mode: 0o600 });
@@ -108,7 +110,9 @@ describe("tester private key output boundary", () => {
       logExecution(executionLog, new Date());
 
       expect(runtimeConfig.privateKey).toBe(privateKey);
+      expect(runtimeConfig.rpcUrl).toBe(rpcUrl);
       expect(output.join("\n")).not.toContain(privateKey);
+      expect(output.join("\n")).not.toContain(rpcUrl);
     } finally {
       stdoutWrite.mockRestore();
       await rm(dir, { recursive: true, force: true });

--- a/apps/tester/src/index.ts
+++ b/apps/tester/src/index.ts
@@ -260,7 +260,7 @@ async function main(): Promise<void> {
         },
       });
     } catch (e) {
-      stopAfterLog = handleLoopError(executionLog, e, { rpcUrl });
+      stopAfterLog = handleLoopError(executionLog, e);
       if (e instanceof TesterTerminalError) {
         process.exitCode = 1;
         stopAfterLog = true;

--- a/apps/tester/src/index.ts
+++ b/apps/tester/src/index.ts
@@ -2,10 +2,12 @@ import { ccc } from "@ckb-ccc/core";
 import { ICKB_DEPOSIT_CAP, convert } from "@ickb/core";
 import { IckbSdk, getConfig, sendAndWaitForCommit } from "@ickb/sdk";
 import {
+  accountPlainCkbBalance,
   createPublicClient,
   formatCkb,
   handleLoopError,
   logExecution,
+  postTransactionAccountPlainCkbBalance,
   randomSleepIntervalMs,
   readRuntimeConfigEnv,
   reachedMaxIterations,
@@ -363,18 +365,7 @@ export function postTransactionPlainCkbBalance(
   state: TesterState,
   accountLocks: ccc.Script[],
 ): bigint {
-  const accountLockHexes = new Set(accountLocks.map((lock) => lock.toHex()));
-  const spentOutPoints = new Set(tx.inputs.map((input) => input.previousOutput.toHex()));
-  const unspentCapacity = plainCapacityBalance(
-    state.account.capacityCells.filter((cell) => !spentOutPoints.has(cell.outPoint.toHex())),
-    accountLockHexes,
-  );
-  const outputCapacity = tx.outputs.reduce(
-    (total, output, index) => total + (isAccountPlainCapacityOutput(output, tx.outputsData[index], accountLockHexes) ? output.capacity : 0n),
-    0n,
-  );
-
-  return unspentCapacity + outputCapacity;
+  return postTransactionAccountPlainCkbBalance(tx, state.account.capacityCells, accountLocks);
 }
 
 export function testerReserveSkip(postTxCkbBalance: bigint): Record<string, string> | undefined {
@@ -394,8 +385,7 @@ export function enforceTesterPlainCkbReserve(
   accountLocks: ccc.Script[],
   scenario: TesterScenario,
 ): Record<string, string> | undefined {
-  const accountLockHexes = new Set(accountLocks.map((lock) => lock.toHex()));
-  const preTxCkbBalance = plainCapacityBalance(state.account.capacityCells, accountLockHexes);
+  const preTxCkbBalance = accountPlainCkbBalance(state.account.capacityCells, accountLocks);
   const postTxCkbBalance = postTransactionPlainCkbBalance(tx, state, accountLocks);
   const reserveSkip = testerReserveSkip(postTxCkbBalance);
   if (reserveSkip === undefined || postTxCkbBalance >= preTxCkbBalance) {
@@ -407,13 +397,6 @@ export function enforceTesterPlainCkbReserve(
     );
   }
   return reserveSkip;
-}
-
-function plainCapacityBalance(cells: readonly ccc.Cell[], accountLockHexes: ReadonlySet<string>): bigint {
-  return cells.reduce(
-    (total, cell) => total + (isAccountPlainCapacityOutput(cell.cellOutput, cell.outputData, accountLockHexes) ? cell.cellOutput.capacity : 0n),
-    0n,
-  );
 }
 
 export function testerExecutionActions(
@@ -911,10 +894,6 @@ function isExplicitCkbReserveScenario(scenario: TesterScenario): boolean {
 
 function isSdkConversionScenario(scenario: TesterScenario): boolean {
   return scenario === "sdk-conversion";
-}
-
-function isAccountPlainCapacityOutput(output: ccc.CellOutput, outputData: string | undefined, accountLockHexes: ReadonlySet<string>): boolean {
-  return output.type === undefined && (outputData ?? "0x") === "0x" && accountLockHexes.has(output.lock.toHex());
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -406,13 +406,17 @@ describe("node utilities", () => {
       tipTimestamp: 456n,
     });
     client.getHeaderByNumber = (): Promise<ccc.ClientBlockHeader | undefined> => {
-      throw new Error("RPC failed via https://user:pass@testnet.example/path?token=secret");
+      const error = new Error("RPC failed via https://user:pass@testnet.example/path?token=secret");
+      error.name = "RpcPreflightError";
+      throw error;
     };
 
-    await expect(verifyChainPreflight(client, "testnet")).rejects.toThrow(
-      "Failed to verify testnet RPC chain identity",
-    );
-    await expect(verifyChainPreflight(client, "testnet")).rejects.not.toThrow(/user|pass|secret|testnet\.example/u);
+    const failure = await verifyChainPreflight(client, "testnet").catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      message: "Failed to verify testnet RPC chain identity",
+      cause: { name: "RpcPreflightError" },
+    });
+    expect(JSON.stringify(failure)).not.toMatch(/user|pass|secret|testnet\.example/u);
   });
 
   it("hides non-Error preflight failures before loop logging starts", async () => {
@@ -432,9 +436,10 @@ describe("node utilities", () => {
       });
     };
 
-    await expect(verifyChainPreflight(client, "testnet")).rejects.toThrow(
-      "Failed to verify testnet RPC chain identity",
-    );
+    await expect(verifyChainPreflight(client, "testnet")).rejects.toMatchObject({
+      message: "Failed to verify testnet RPC chain identity",
+      cause: { type: "object" },
+    });
   });
 
   it("normalizes retryable preflight transport failures", async () => {

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -5,23 +5,24 @@ import { join, resolve } from "node:path";
 import process from "node:process";
 import { tmpdir } from "node:os";
 import { describe, expect, it, vi } from "vitest";
+import * as nodeUtils from "./index.js";
 import {
   assertChainPreflight,
   CHAIN_IDENTITIES,
   createPublicClient,
   formatCkb,
   handleLoopError,
+  isRetryableCkbStateRaceError,
+  isRetryableRpcTransportError,
   logExecution,
   parseMaxIterations,
-  parseMaxRetryableAttempts,
   parseRuntimeConfig,
   parsePrivateKey,
+  postTransactionAccountPlainCkbBalance,
   readRuntimeConfigEnv,
   parseSleepInterval,
   randomSleepIntervalMs,
   readChainPreflight,
-  redactRpcUrl,
-  redactSecretText,
   reachedMaxIterations,
   signerAccountLocks,
   STOP_EXIT_CODE,
@@ -31,6 +32,14 @@ import {
 } from "./index.js";
 
 describe("node utilities", () => {
+  it("does not export generic secret-policing helpers", () => {
+    expect("assertNoPrivateKeyMaterial" in nodeUtils).toBe(false);
+    expect("assertNoSecretMaterial" in nodeUtils).toBe(false);
+    expect("SecretMaterialLogError" in nodeUtils).toBe(false);
+    expect("PrivateKeyMaterialLogError" in nodeUtils).toBe(false);
+    expect("sanitizeLogValue" in nodeUtils).toBe(false);
+  });
+
   it("formats CKB values without losing bigint precision", () => {
     const whole = 123456789012345678901234567890n;
 
@@ -46,8 +55,8 @@ describe("node utilities", () => {
     expect(parseSleepInterval(1073741, "BOT_CONFIG_FILE")).toBe(1073741000);
   });
 
-  it("rejects invalid sleep intervals", () => {
-    for (const value of [undefined, Number.NaN, Infinity, -1, 0, 0.5, 1073741.824, 9007199254741]) {
+  it("rejects missing and sub-second sleep intervals", () => {
+    for (const value of [undefined, Number.NaN, Infinity, 0, 0.5, 1073741.824, 9007199254741]) {
       expect(() => parseSleepInterval(value, "BOT_CONFIG_FILE")).toThrow(
         "Invalid env BOT_CONFIG_FILE",
       );
@@ -67,11 +76,6 @@ describe("node utilities", () => {
     expect(() => parseMaxIterations(1.5, "BOT_CONFIG_FILE")).toThrow(
       "Invalid env BOT_CONFIG_FILE",
     );
-    expect(parseMaxRetryableAttempts(undefined, "BOT_CONFIG_FILE")).toBeUndefined();
-    expect(parseMaxRetryableAttempts(3, "BOT_CONFIG_FILE")).toBe(3);
-    expect(() => parseMaxRetryableAttempts(0, "BOT_CONFIG_FILE")).toThrow(
-      "Invalid env BOT_CONFIG_FILE",
-    );
   });
 
   it("randomizes sleep with triangular jitter centered on the interval", () => {
@@ -84,6 +88,7 @@ describe("node utilities", () => {
       sum + randomSleepIntervalMs(1000, sequence(first, 1 - first))
     ), 0) / samples.length;
     expect(average).toBe(1000);
+    expect(randomSleepIntervalMs(1073741823, sequence(0.999999, 0.999999))).toBeLessThanOrEqual(2147483647);
   });
 
   it("parses private keys as exact 0x-prefixed lowercase hex", () => {
@@ -255,6 +260,37 @@ describe("node utilities", () => {
     ]);
   });
 
+  it("counts post-transaction account plain CKB from unspent cells and new outputs", () => {
+    const lock = script("11");
+    const otherLock = script("22");
+    const spent = capacityCell(ccc.fixedPointFrom(1000), lock, "aa");
+    const unspent = capacityCell(ccc.fixedPointFrom(2000), lock, "bb");
+    const typed = ccc.Cell.from({
+      outPoint: { txHash: byte32FromByte("cc"), index: 0n },
+      cellOutput: { capacity: ccc.fixedPointFrom(4000), lock, type: script("33") },
+      outputData: "0x",
+    });
+    const data = ccc.Cell.from({
+      outPoint: { txHash: byte32FromByte("dd"), index: 0n },
+      cellOutput: { capacity: ccc.fixedPointFrom(8000), lock },
+      outputData: "0x1234",
+    });
+    const tx = ccc.Transaction.default();
+    tx.inputs.push(ccc.CellInput.from({ previousOutput: spent.outPoint }));
+    tx.outputs.push(
+      ccc.CellOutput.from({ capacity: ccc.fixedPointFrom(300), lock }),
+      ccc.CellOutput.from({ capacity: ccc.fixedPointFrom(500), lock, type: script("33") }),
+      ccc.CellOutput.from({ capacity: ccc.fixedPointFrom(700), lock: otherLock }),
+    );
+    tx.outputsData.push("0x", "0x", "0x");
+
+    expect(postTransactionAccountPlainCkbBalance(
+      tx,
+      [spent, unspent, typed, data],
+      [lock],
+    )).toBe(ccc.fixedPointFrom(2300));
+  });
+
   it("creates network-specific public clients and forwards custom RPC URLs", () => {
     const mainnet = createPublicClient("mainnet", "https://mainnet.example");
     const testnet = createPublicClient("testnet", undefined);
@@ -296,12 +332,10 @@ describe("node utilities", () => {
       tipHash: byte32FromByte("22"),
       tipNumber: 123n,
       tipTimestamp: 456n,
-      url: "https://user:pass@testnet.example/rpc/path?token=secret&plain=value",
     });
 
     await expect(readChainPreflight(client, "testnet")).resolves.toEqual({
       chain: "testnet",
-      redactedRpcUrl: "https://redacted:redacted@testnet.example/...?token=redacted&plain=redacted",
       expected: CHAIN_IDENTITIES.testnet,
       observed: {
         genesisHash: CHAIN_IDENTITIES.testnet.genesisHash,
@@ -326,7 +360,6 @@ describe("node utilities", () => {
   it("rejects mismatched public chain identity evidence", () => {
     expect(() => assertChainPreflight({
       chain: "testnet",
-      redactedRpcUrl: "https://rpc.example/",
       expected: CHAIN_IDENTITIES.testnet,
       observed: {
         genesisHash: CHAIN_IDENTITIES.mainnet.genesisHash,
@@ -343,97 +376,100 @@ describe("node utilities", () => {
     );
   });
 
-  it("redacts RPC URLs when chain preflight reads fail", async () => {
+  it("hides non-public preflight failure details before loop logging starts", async () => {
     const client = preflightClient({
       addressPrefix: "ckt",
       genesisHash: CHAIN_IDENTITIES.testnet.genesisHash,
       tipHash: byte32FromByte("22"),
       tipNumber: 123n,
       tipTimestamp: 456n,
-      url: "https://user:pass@testnet.example/rpc/path?token=secret",
     });
     client.getHeaderByNumber = (): Promise<ccc.ClientBlockHeader | undefined> => {
-      throw new Error("RPC failed: https://user:pass@testnet.example/rpc/path?token=secret user pass secret");
+      throw new Error("RPC failed via https://user:pass@testnet.example/path?token=secret");
     };
 
     await expect(verifyChainPreflight(client, "testnet")).rejects.toThrow(
-      "RPC failed: https://redacted:redacted@testnet.example/...?token=redacted",
+      "Failed to verify testnet RPC chain identity",
     );
-    await expect(verifyChainPreflight(client, "testnet")).rejects.not.toThrow(/secret|user:pass/u);
-    await expect(verifyChainPreflight(client, "testnet")).rejects.not.toThrow(/\buser\b|\bpass\b/u);
+    await expect(verifyChainPreflight(client, "testnet")).rejects.not.toThrow(/user|pass|secret|testnet\.example/u);
   });
 
-  it("redacts non-Error preflight failures without losing thrown values", async () => {
+  it("hides non-Error preflight failures before loop logging starts", async () => {
     const client = preflightClient({
       addressPrefix: "ckt",
       genesisHash: CHAIN_IDENTITIES.testnet.genesisHash,
       tipHash: byte32FromByte("22"),
       tipNumber: 123n,
       tipTimestamp: 456n,
-      url: "https://testnet.example/rpc/path?token=secret",
     });
     client.getHeaderByNumber = (): Promise<ccc.ClientBlockHeader | undefined> => {
       // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- Covers defensive handling for non-Error RPC failures.
       return Promise.reject({
         reason: "failed",
         amount: 9007199254740993n,
-        token: "secret",
+        reasonCode: "transport",
       });
     };
 
     await expect(verifyChainPreflight(client, "testnet")).rejects.toThrow(
-      '{"reason":"failed","amount":"9007199254740993"}',
+      "Failed to verify testnet RPC chain identity",
     );
-    await expect(verifyChainPreflight(client, "testnet")).rejects.toMatchObject({
-      cause: {
-        reason: "failed",
-        amount: "9007199254740993",
-      },
+  });
+
+  it("normalizes retryable preflight transport failures", async () => {
+    const client = preflightClient({
+      addressPrefix: "ckt",
+      genesisHash: CHAIN_IDENTITIES.testnet.genesisHash,
+      tipHash: byte32FromByte("22"),
+      tipNumber: 123n,
+      tipTimestamp: 456n,
     });
+    client.getHeaderByNumber = (): Promise<ccc.ClientBlockHeader | undefined> => {
+      throw new TypeError("fetch failed");
+    };
+
+    await expect(verifyChainPreflight(client, "testnet")).rejects.toMatchObject({
+      message: "fetch failed",
+      cause: { name: "TypeError", message: "fetch failed" },
+    });
+    await expect(verifyChainPreflight(client, "testnet").catch((error: unknown) => {
+      expect(isRetryableRpcTransportError(error)).toBe(true);
+    })).resolves.toBeUndefined();
   });
 
-  it("redacts credential-bearing RPC URLs", () => {
-    expect(redactRpcUrl("https://rpc.example/")).toBe("https://rpc.example/");
-    expect(redactRpcUrl("https://rpc.example/path?token=abc&key=def")).toBe(
-      "https://rpc.example/...?token=redacted&key=redacted",
-    );
-    expect(redactRpcUrl("not a url")).toBe("<invalid-url>");
+  it("classifies retryable RPC transport failures", async () => {
+    const { isRetryableRpcTransportError } = await import("./index.js");
+
+    expect(isRetryableRpcTransportError(new TypeError("fetch failed"))).toBe(true);
+    expect(isRetryableRpcTransportError(new Error("fetch failed", { cause: new TypeError("fetch failed") }))).toBe(true);
+    expect(isRetryableRpcTransportError(new Error("fetch failed"))).toBe(false);
+    expect(isRetryableRpcTransportError(new Error("Invalid testnet RPC chain identity"))).toBe(false);
   });
 
-  it("redacts runtime secrets from text", () => {
-    const privateKey = `0x${"11".repeat(32)}`;
-    const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
+  it("classifies observed CKB state-race send failures", () => {
+    expect(isRetryableCkbStateRaceError(Object.assign(new Error("Client request error PoolRejectedRBF"), {
+      code: -1111,
+      data: "RBFRejected(\"Tx's current fee is 11795, expect it to >= 12326 to replace old txs\")",
+      currentFee: 11795n,
+      leastFee: 12326n,
+    }))).toBe(true);
+    expect(isRetryableCkbStateRaceError(Object.assign(new Error("Client request error TransactionFailedToResolve"), {
+      code: -301,
+      data: `Resolve(Unknown(OutPoint(0x${"11".repeat(32)}00000000)))`,
+    }))).toBe(true);
+    expect(isRetryableCkbStateRaceError({
+      code: -301,
+      data: `Resolve(Dead(OutPoint(0x${"11".repeat(32)}00000000)))`,
+    })).toBe(true);
+    expect(isRetryableCkbStateRaceError(Object.assign(new Error("Client request error PoolRejectedDuplicatedTransaction"), {
+      code: -1107,
+      data: `Duplicated(Byte32(0x${"22".repeat(32)}))`,
+      txHash: `0x${"22".repeat(32)}`,
+    }))).toBe(true);
 
-    expect(redactSecretText(
-      `failed for ${privateKey} via ${rpcUrl}`,
-      { privateKey, rpcUrl },
-    )).toBe(
-      "failed for <redacted-private-key> via https://redacted:redacted@testnet.example/...?token=redacted",
-    );
-    expect(redactSecretText(
-      "fetch failed for https://testnet.example/rpc/path?token=secret auth user:pass",
-      { rpcUrl },
-    )).toBe(
-      "fetch failed for https://testnet.example/rpc/path?token=<redacted-rpc-query> auth " +
-        "<redacted-rpc-username>:<redacted-rpc-password>",
-    );
-    expect(redactSecretText(
-      "fetch failed for token=a%2Fb decoded=a/b plain=value",
-      { rpcUrl: "https://testnet.example/rpc/path?token=a%2Fb&plain=value" },
-    )).toBe(
-      "fetch failed for token=<redacted-rpc-query> decoded=<redacted-rpc-query> " +
-        "plain=<redacted-rpc-query>",
-    );
-    expect(redactSecretText("empty secrets stay intact", { privateKey: "", rpcUrl: "" })).toBe(
-      "empty secrets stay intact",
-    );
-    expect(redactSecretText(
-      "fetch failed for https://%E0%A4%A@testnet.example/rpc?token=secret %E0%A4%A",
-      { rpcUrl: "https://%E0%A4%A@testnet.example/rpc?token=secret" },
-    )).toBe(
-      "fetch failed for https://redacted@testnet.example/...?token=redacted " +
-        "<redacted-rpc-username>",
-    );
+    expect(isRetryableCkbStateRaceError({ code: -301, data: "Resolve(InvalidHeader(Byte32(0x...)))" })).toBe(false);
+    expect(isRetryableCkbStateRaceError({ code: -302, data: `Resolve(Unknown(OutPoint(0x${"11".repeat(32)}00000000)))` })).toBe(false);
+    expect(isRetryableCkbStateRaceError(new Error("RBFRejected"))).toBe(false);
   });
 
   it("serializes error-like values for JSON logs", () => {
@@ -449,6 +485,30 @@ describe("node utilities", () => {
     const emptyLog: Record<string, unknown> = {};
     expect(handleLoopError(emptyLog, undefined)).toBe(false);
     expect(emptyLog.error).toBe("Empty Error");
+  });
+
+  it("preserves public CKB RPC Error metadata in execution logs", () => {
+    const executionLog: Record<string, unknown> = {};
+    const error = Object.assign(new Error("Client request error TransactionFailedToResolve"), {
+      code: -301,
+      data: `Resolve(Unknown(OutPoint(0x${"11".repeat(32)}00000000)))`,
+      outPoint: {
+        txHash: `0x${"11".repeat(32)}`,
+        index: 0n,
+      },
+    });
+
+    expect(handleLoopError(executionLog, error)).toBe(false);
+    expect(executionLog.error).toMatchObject({
+      name: "Error",
+      message: "Client request error TransactionFailedToResolve",
+      code: -301,
+      data: `Resolve(Unknown(OutPoint(0x${"11".repeat(32)}00000000)))`,
+      outPoint: {
+        txHash: `0x${"11".repeat(32)}`,
+        index: "0",
+      },
+    });
   });
 
   it("stops after broadcast confirmation timeouts", () => {
@@ -473,83 +533,55 @@ describe("node utilities", () => {
       message: "Transaction confirmation timed out",
       txHash,
       status: "sent",
+      isTimeout: true,
     });
 
     process.exitCode = undefined;
   });
 
-  it("redacts runtime secrets from loop errors", () => {
-    const privateKey = `0x${"11".repeat(32)}`;
-    const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
-    const error = new Error(`failed for ${privateKey} via ${rpcUrl}`, {
-      cause: new Error(`nested ${privateKey} via ${rpcUrl}`),
-    });
-    error.stack = `stack with ${privateKey} and ${rpcUrl}`;
-    (error.cause as Error).stack = `nested stack with ${privateKey} and ${rpcUrl}`;
-    const executionLog: Record<string, unknown> = {};
+  it("records non-timeout transaction confirmation failures distinctly", () => {
+    const txHash = byte32FromByte("34");
+    const executionLog: Record<string, unknown> = { txHash };
 
-    expect(handleLoopError(executionLog, error, { privateKey, rpcUrl })).toBe(false);
-    const serialized = JSON.stringify(executionLog);
-
-    expect(serialized).not.toContain(privateKey);
-    expect(serialized).not.toContain("user:pass");
-    expect(serialized).not.toContain("secret");
-    expect(serialized).toContain("<redacted-private-key>");
-    expect(serialized).toContain("https://redacted:redacted@testnet.example/...?token=redacted");
+    expect(handleLoopError(executionLog, transactionError(false, txHash))).toBe(false);
     expect(executionLog.error).toMatchObject({
-      cause: {
-        name: "Error",
-        message: "nested <redacted-private-key> via " +
-          "https://redacted:redacted@testnet.example/...?token=redacted",
-      },
+      name: "TransactionConfirmationError",
+      message: "Transaction confirmation timed out",
+      txHash,
+      status: "rejected",
+      isTimeout: false,
     });
   });
 
-  it("redacts runtime secrets from non-Error loop failures", () => {
-    const privateKey = `0x${"11".repeat(32)}`;
-    const rpcUrl = "https://user:pass@testnet.example/rpc/path?token=secret";
+  it("preserves CKB debugging metadata from non-Error loop failures", () => {
+    const rpcUrl = "https://testnet.example/rpc/path";
     const executionLog: Record<string, unknown> = {};
     const circular: Record<string, unknown> = {};
     circular.self = circular;
 
     expect(handleLoopError(executionLog, {
-      message: `failed for ${privateKey} via ${rpcUrl}`,
-      privateKey,
+      message: `failed via ${rpcUrl}`,
       rpcUrl,
       amount: 9007199254740993n,
       nested: {
-        private_key: privateKey,
         rpc_url: rpcUrl,
-        password: "hunter2",
-        apiKey: "api-key-value",
-        accessToken: "secret-token",
-        api_secret: "secret-value",
-        message: `nested ${privateKey}`,
+        message: "nested public evidence",
       },
       circular,
-    }, { privateKey, rpcUrl })).toBe(false);
+    })).toBe(false);
     const serialized = JSON.stringify(executionLog);
 
-    expect(serialized).not.toContain(privateKey);
-    expect(serialized).not.toContain("user:pass");
-    expect(serialized).not.toContain("secret");
-    expect(serialized).toContain("<redacted-private-key>");
-    expect(serialized).toContain("https://redacted:redacted@testnet.example/...?token=redacted");
+    expect(serialized).toContain(rpcUrl);
     expect(executionLog.error).toMatchObject({
-      message: "failed for <redacted-private-key> via " +
-        "https://redacted:redacted@testnet.example/...?token=redacted",
+      message: "failed via " + rpcUrl,
+      rpcUrl,
       amount: "9007199254740993",
-      nested: { message: "nested <redacted-private-key>" },
+      nested: {
+        rpc_url: rpcUrl,
+        message: "nested public evidence",
+      },
       circular: { self: "[Circular]" },
     });
-    expect(executionLog.error).not.toHaveProperty("rpcUrl");
-    expect(executionLog.error).not.toHaveProperty("privateKey");
-    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("rpc_url");
-    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("private_key");
-    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("password");
-    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("apiKey");
-    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("accessToken");
-    expect((executionLog.error as { nested?: unknown }).nested).not.toHaveProperty("api_secret");
   });
 
   it("logs one JSON entry with elapsed seconds", () => {
@@ -603,41 +635,81 @@ describe("node utilities", () => {
     stdoutWrite.mockRestore();
   });
 
-  it("preserves public CKB metadata in JSON logs", () => {
+  it("preserves CKB debugging metadata", () => {
     const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const txHash = byte32FromByte("55");
 
     writeJsonLine({
       txHash,
       witness: "witnesses: 0x" + "22".repeat(80),
+      witnesses: ["0x" + "22".repeat(80)],
+      inputs: [{}],
+      outputs: [{}],
+      outputsData: ["0x" + "22".repeat(80)],
+      cellDeps: [{}],
+      headerDeps: [{}],
       signedTx: "signed transaction 0x" + "33".repeat(80),
+      tx: { inputs: [], outputs: [], witnesses: [] },
+      rawTransaction: { inputs: [], outputs: [], witnesses: [] },
       script: JSON.stringify({
         codeHash: "0x" + "44".repeat(32),
         hashType: "type",
         args: "0x" + "55".repeat(20),
       }),
+      lock: { codeHash: "0x" + "44".repeat(32), hashType: "type", args: "0x" },
+      cell: { cellOutput: { lock: script("66") } },
+      transactionShape: { inputs: 1, outputs: 2, witnesses: 3 },
       env: "testnet",
+      environment: { BOT_CONFIG_FILE: "/run/credentials/config.json" },
+      config: { chain: "testnet" },
     });
 
     const parsed = JSON.parse(String(stdoutWrite.mock.calls[0]?.[0])) as {
       txHash: string;
       witness: string;
+      witnesses: string[];
+      inputs: unknown[];
+      outputs: unknown[];
+      outputsData: string[];
+      cellDeps: unknown[];
+      headerDeps: unknown[];
       signedTx: string;
+      tx: { inputs: unknown[]; outputs: unknown[]; witnesses: unknown[] };
+      rawTransaction: { inputs: unknown[]; outputs: unknown[]; witnesses: unknown[] };
       script: string;
+      lock: { codeHash: string; hashType: string; args: string };
+      cell: { cellOutput: { lock: unknown } };
+      transactionShape: { inputs: number; outputs: number; witnesses: number };
       env: string;
+      environment: { BOT_CONFIG_FILE: string };
+      config: { chain: string };
     };
     expect(parsed.txHash).toBe(txHash);
     expect(parsed.witness).toBe("witnesses: 0x" + "22".repeat(80));
+    expect(parsed.witnesses).toEqual(["0x" + "22".repeat(80)]);
+    expect(parsed.inputs).toEqual([{}]);
+    expect(parsed.outputs).toEqual([{}]);
+    expect(parsed.outputsData).toEqual(["0x" + "22".repeat(80)]);
+    expect(parsed.cellDeps).toEqual([{}]);
+    expect(parsed.headerDeps).toEqual([{}]);
     expect(parsed.signedTx).toBe("signed transaction 0x" + "33".repeat(80));
+    expect(parsed.tx).toEqual({ inputs: [], outputs: [], witnesses: [] });
+    expect(parsed.rawTransaction).toEqual({ inputs: [], outputs: [], witnesses: [] });
     expect(parsed.script).toBe(JSON.stringify({
       codeHash: "0x" + "44".repeat(32),
       hashType: "type",
       args: "0x" + "55".repeat(20),
     }));
+    expect(parsed.lock).toEqual({ codeHash: "0x" + "44".repeat(32), hashType: "type", args: "0x" });
+    expect(parsed.cell).toHaveProperty("cellOutput");
+    expect(parsed.transactionShape).toEqual({ inputs: 1, outputs: 2, witnesses: 3 });
     expect(parsed.env).toBe("testnet");
+    expect(parsed.environment).toEqual({ BOT_CONFIG_FILE: "/run/credentials/config.json" });
+    expect(parsed.config).toEqual({ chain: "testnet" });
 
     stdoutWrite.mockRestore();
   });
+
 });
 
 function sequence(...values: number[]): () => number {
@@ -654,24 +726,29 @@ function transactionError(isTimeout: boolean, txHash = byte32FromByte("11")): Er
   });
 }
 
+function capacityCell(capacity: bigint, lock: ccc.Script, txByte: string): ccc.Cell {
+  return ccc.Cell.from({
+    outPoint: { txHash: byte32FromByte(txByte), index: 0n },
+    cellOutput: { capacity, lock },
+    outputData: "0x",
+  });
+}
+
 function preflightClient({
   addressPrefix,
   genesisHash,
   tipHash,
   tipNumber,
   tipTimestamp,
-  url,
 }: {
   addressPrefix: string;
   genesisHash: `0x${string}`;
   tipHash: `0x${string}`;
   tipNumber: bigint;
   tipTimestamp: bigint;
-  url: string;
 }): ChainPreflightClient {
   return {
     addressPrefix,
-    url,
     getHeaderByNumber: async (blockNumber): Promise<ccc.ClientBlockHeader | undefined> => {
       await Promise.resolve();
       if (blockNumber !== 0n) {

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { describe, expect, it, vi } from "vitest";
 import * as nodeUtils from "./index.js";
 import {
+  accountPlainCkbBalance,
   assertChainPreflight,
   CHAIN_IDENTITIES,
   createPublicClient,
@@ -258,6 +259,26 @@ describe("node utilities", () => {
       primaryLock,
       otherLock,
     ]);
+  });
+
+  it("counts account plain CKB from owned plain capacity cells only", () => {
+    const lock = script("11");
+    const otherLock = script("22");
+    const unspent = capacityCell(ccc.fixedPointFrom(2000), lock, "bb");
+    const typed = ccc.Cell.from({
+      outPoint: { txHash: byte32FromByte("cc"), index: 0n },
+      cellOutput: { capacity: ccc.fixedPointFrom(4000), lock, type: script("33") },
+      outputData: "0x",
+    });
+    const data = ccc.Cell.from({
+      outPoint: { txHash: byte32FromByte("dd"), index: 0n },
+      cellOutput: { capacity: ccc.fixedPointFrom(8000), lock },
+      outputData: "0x1234",
+    });
+
+    expect(accountPlainCkbBalance([unspent, typed, data, capacityCell(100n, otherLock, "ee")], [lock])).toBe(
+      ccc.fixedPointFrom(2000),
+    );
   });
 
   it("counts post-transaction account plain CKB from unspent cells and new outputs", () => {

--- a/packages/node-utils/src/index.test.ts
+++ b/packages/node-utils/src/index.test.ts
@@ -645,16 +645,22 @@ describe("node utilities", () => {
     writeJsonLine({
       type: "bot.decision.skipped",
       amount: 9007199254740993n,
+      observedAt: new Date("2026-01-02T03:04:05.006Z"),
+      invalidAt: new Date(Number.NaN),
     });
 
     expect(stdoutWrite).toHaveBeenCalledTimes(1);
     const parsed = JSON.parse(String(stdoutWrite.mock.calls[0]?.[0])) as {
       type: string;
       amount: string;
+      observedAt: string;
+      invalidAt: null;
     };
     expect(parsed).toEqual({
       type: "bot.decision.skipped",
       amount: "9007199254740993",
+      observedAt: "2026-01-02T03:04:05.006Z",
+      invalidAt: null,
     });
     expect(String(stdoutWrite.mock.calls[0]?.[0])).toMatch(/\n$/u);
 

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -423,6 +423,17 @@ export async function signerAccountLocks(
   ])];
 }
 
+export function accountPlainCkbBalance(
+  capacityCells: readonly ccc.Cell[],
+  accountLocks: readonly ccc.Script[],
+): bigint {
+  const accountLockHexes = new Set(accountLocks.map((lock) => lock.toHex()));
+  return capacityCells.reduce(
+    (total, cell) => total + plainCapacity(cell.cellOutput, cell.outputData, accountLockHexes),
+    0n,
+  );
+}
+
 export function postTransactionAccountPlainCkbBalance(
   tx: ccc.Transaction,
   capacityCells: readonly ccc.Cell[],
@@ -432,18 +443,21 @@ export function postTransactionAccountPlainCkbBalance(
   const spentOutPoints = new Set(tx.inputs.map((input) => input.previousOutput.toHex()));
   const unspentCapacity = capacityCells.reduce(
     (total, cell) =>
-      spentOutPoints.has(cell.outPoint.toHex()) ||
-      !isAccountPlainCapacityOutput(cell.cellOutput, cell.outputData, accountLockHexes)
+      spentOutPoints.has(cell.outPoint.toHex())
         ? total
-        : total + cell.cellOutput.capacity,
+        : total + plainCapacity(cell.cellOutput, cell.outputData, accountLockHexes),
     0n,
   );
   const outputCapacity = tx.outputs.reduce(
-    (total, output, index) => total + (isAccountPlainCapacityOutput(output, tx.outputsData[index], accountLockHexes) ? output.capacity : 0n),
+    (total, output, index) => total + plainCapacity(output, tx.outputsData[index], accountLockHexes),
     0n,
   );
 
   return unspentCapacity + outputCapacity;
+}
+
+function plainCapacity(output: ccc.CellOutput, outputData: string | undefined, accountLockHexes: Set<string>): bigint {
+  return isAccountPlainCapacityOutput(output, outputData, accountLockHexes) ? output.capacity : 0n;
 }
 
 function isAccountPlainCapacityOutput(output: ccc.CellOutput, outputData: string | undefined, accountLockHexes: Set<string>): boolean {

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -194,7 +194,7 @@ export function isRetryableRpcTransportError(error: unknown): boolean {
   if (!(error instanceof Error) || error.message !== "fetch failed") {
     return false;
   }
-  const cause = (error as { cause?: unknown }).cause;
+  const cause = "cause" in error ? error.cause : undefined;
   return typeof cause === "object" && cause !== null &&
     "name" in cause && cause.name === "TypeError" &&
     "message" in cause && cause.message === "fetch failed";
@@ -464,7 +464,7 @@ function errorToLogValue(
     };
     try {
       if ("cause" in error) {
-        logged.cause = errorToLogValue((error as { cause?: unknown }).cause, seen);
+        logged.cause = errorToLogValue(error.cause, seen);
       }
       return logged;
     } finally {

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -7,8 +7,7 @@ import { setTimeout } from "node:timers";
 
 const CKB = 100000000n;
 const SECP256K1_ORDER = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
-// Jitter can double the configured interval; keep the result within Node's timer limit.
-const MAX_SAFE_SLEEP_INTERVAL_MS = 1_073_741_823;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 export const STOP_EXIT_CODE = 2;
 
@@ -44,12 +43,11 @@ export const CHAIN_IDENTITIES = {
 
 export type ChainPreflightClient = Pick<
   ccc.Client,
-  "addressPrefix" | "getHeaderByNumber" | "getTipHeader" | "url"
+  "addressPrefix" | "getHeaderByNumber" | "getTipHeader"
 >;
 
 export interface ChainPreflightEvidence {
   chain: SupportedChain;
-  redactedRpcUrl: string;
   expected: ChainIdentity;
   observed: {
     genesisHash: ccc.Hex;
@@ -86,7 +84,6 @@ export async function readChainPreflight(
 
   return {
     chain,
-    redactedRpcUrl: redactRpcUrl(client.url),
     expected,
     observed: {
       genesisHash: genesis.hash,
@@ -132,130 +129,43 @@ export async function verifyChainPreflight(
   try {
     return assertChainPreflight(await readChainPreflight(client, chain));
   } catch (error) {
-    const secrets = { rpcUrl: client.url };
-    throw new Error(redactRpcUrlInError(error, secrets), {
-      cause: errorToLogValue(error, secrets, new WeakSet()),
-    });
+    if (isPublicChainPreflightFailure(error, chain)) {
+      throw new Error(errorMessage(error), {
+        cause: errorToLogValue(error, new WeakSet()),
+      });
+    }
+    if (isRetryableRpcTransportError(error)) {
+      throw new Error("fetch failed", {
+        cause: { name: "TypeError", message: "fetch failed" },
+      });
+    }
+    throw new Error(`Failed to verify ${chain} RPC chain identity`);
   }
 }
 
-function redactRpcUrlInError(error: unknown, secrets: SecretRedactionContext): string {
-  const message = typeof error === "string"
+function isPublicChainPreflightFailure(error: unknown, chain: SupportedChain): boolean {
+  const message = errorMessage(error);
+  return message === `Missing ${chain} genesis header` ||
+    message.startsWith(`Invalid ${chain} RPC chain identity:`);
+}
+
+function errorMessage(error: unknown): string {
+  return typeof error === "string"
     ? error
     : error instanceof Error
       ? error.message
-      : stringifyErrorMessage(error, secrets);
-  return redactSecretText(message, secrets);
+      : stringifyErrorMessage(error);
 }
 
-export function redactSecretText(text: string, secrets: SecretRedactionContext = {}): string {
-  let redacted = text;
-  if (secrets.privateKey) {
-    redacted = redacted.split(secrets.privateKey).join("<redacted-private-key>");
-  }
-  if (secrets.rpcUrl) {
-    redacted = redacted.split(secrets.rpcUrl).join(secrets.redactedRpcUrl ?? redactRpcUrl(secrets.rpcUrl));
-    redacted = redactRpcUrlSecrets(redacted, secrets.rpcUrl);
-  }
-  return redacted;
-}
-
-function stringifyErrorMessage(error: unknown, secrets: SecretRedactionContext): string {
+function stringifyErrorMessage(error: unknown): string {
   if (error === undefined || error === null) {
     return "Unknown error";
   }
   try {
-    return JSON.stringify(sanitizeLogValue(error, secrets, new WeakSet()), jsonLogReplacer);
+    return JSON.stringify(toJsonLogValue(error, new WeakSet()), jsonLogReplacer);
   } catch {
     return "Unknown error";
   }
-}
-
-function redactRpcUrlSecrets(text: string, rpcUrl: string): string {
-  let url: URL;
-  try {
-    url = new URL(rpcUrl);
-  } catch {
-    return text;
-  }
-
-  const replacements = new Array<[string, string]>();
-  if (url.username !== "") {
-    replacements.push([url.username, "<redacted-rpc-username>"]);
-    replacements.push([safeDecodeURIComponent(url.username), "<redacted-rpc-username>"]);
-  }
-  if (url.password !== "") {
-    replacements.push([url.password, "<redacted-rpc-password>"]);
-    replacements.push([safeDecodeURIComponent(url.password), "<redacted-rpc-password>"]);
-  }
-  for (const value of url.searchParams.values()) {
-    replacements.push([value, "<redacted-rpc-query>"]);
-  }
-  for (const value of rawSearchParamValues(url.search)) {
-    replacements.push([value, "<redacted-rpc-query>"]);
-  }
-  return replaceUrlSecrets(text, replacements);
-}
-
-function rawSearchParamValues(search: string): string[] {
-  const query = search.startsWith("?") ? search.slice(1) : search;
-  if (query === "") {
-    return [];
-  }
-  return query.split("&").map((part) => {
-    const separator = part.indexOf("=");
-    return separator === -1 ? "" : part.slice(separator + 1);
-  });
-}
-
-function replaceUrlSecrets(text: string, replacements: Array<[string, string]>): string {
-  const unique = new Map(replacements.filter(([secret]) => secret !== ""));
-  if (unique.size === 0) {
-    return text;
-  }
-  const pattern = [...unique.keys()]
-    .sort((left, right) => right.length - left.length)
-    .map(escapeRegExp)
-    .join("|");
-  return text.replace(new RegExp(pattern, "gu"), (match) => unique.get(match) ?? match);
-}
-
-function safeDecodeURIComponent(text: string): string {
-  try {
-    return decodeURIComponent(text);
-  } catch {
-    return "";
-  }
-}
-
-function escapeRegExp(text: string): string {
-  return text.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-}
-
-export function redactRpcUrl(rpcUrl: string): string {
-  let url: URL;
-  try {
-    url = new URL(rpcUrl);
-  } catch {
-    return "<invalid-url>";
-  }
-
-  if (url.username !== "" || url.password !== "") {
-    url.username = "redacted";
-    url.password = url.password === "" ? "" : "redacted";
-  }
-  if (url.pathname !== "" && url.pathname !== "/") {
-    url.pathname = "/...";
-  }
-  if (url.search !== "") {
-    const redactedParams = new URLSearchParams();
-    for (const [key] of url.searchParams) {
-      redactedParams.append(key, "redacted");
-    }
-    url.search = redactedParams.toString();
-  }
-
-  return url.toString();
 }
 
 export function formatCkb(balance: bigint): string {
@@ -275,6 +185,38 @@ export function jsonLogReplacer(_: unknown, value: unknown): unknown {
   return typeof value === "bigint" ? value.toString() : value;
 }
 
+const UNSAFE_LOG_VALUE = "[Unsupported log value]";
+
+export function isRetryableRpcTransportError(error: unknown): boolean {
+  if (error instanceof TypeError && error.message === "fetch failed") {
+    return true;
+  }
+  if (!(error instanceof Error) || error.message !== "fetch failed") {
+    return false;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  return typeof cause === "object" && cause !== null &&
+    "name" in cause && cause.name === "TypeError" &&
+    "message" in cause && cause.message === "fetch failed";
+}
+
+export function isRetryableCkbStateRaceError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const code = "code" in error ? error.code : undefined;
+  const data = "data" in error ? error.data : undefined;
+  if (typeof code !== "number" || typeof data !== "string") {
+    return false;
+  }
+  return code === -1111 && data.includes("RBFRejected(") ||
+    code === -301 && (
+      data.includes("Resolve(Unknown(OutPoint(") ||
+      data.includes("Resolve(Dead(OutPoint(")
+    ) ||
+    code === -1107 && data.includes("Duplicated(Byte32(");
+}
+
 export function parseSleepInterval(
   intervalSeconds: number | undefined,
   envName: string,
@@ -284,7 +226,7 @@ export function parseSleepInterval(
   }
 
   const intervalMs = intervalSeconds * 1000;
-  if (!Number.isSafeInteger(intervalMs) || intervalMs > MAX_SAFE_SLEEP_INTERVAL_MS) {
+  if (!Number.isSafeInteger(intervalMs) || intervalMs > Math.floor(MAX_TIMER_DELAY_MS / 2)) {
     throw new Error("Invalid env " + envName);
   }
 
@@ -307,15 +249,9 @@ export type RuntimeConfig = {
   privateKey: `0x${string}`;
   rpcUrl?: string;
   sleepIntervalMs: number;
-  maxIterations?: number;
-  maxRetryableAttempts?: number;
+  maxIterations: number | undefined;
+  maxRetryableAttempts: number | undefined;
 };
-
-export interface SecretRedactionContext {
-  privateKey?: string;
-  rpcUrl?: string;
-  redactedRpcUrl?: string;
-}
 
 export function parseRpcUrl(rpcUrl: string, envName: string): string {
   for (let index = 0; index < rpcUrl.length; index += 1) {
@@ -339,21 +275,17 @@ export function parseRpcUrl(rpcUrl: string, envName: string): string {
   return rpcUrl;
 }
 
+function parseOptionalRpcUrl(rpcUrl: unknown, envName: string): string | undefined {
+  if (rpcUrl === undefined) {
+    return undefined;
+  }
+  if (typeof rpcUrl !== "string") {
+    throw new Error("Invalid env " + envName);
+  }
+  return parseRpcUrl(rpcUrl, envName);
+}
+
 export function parseMaxIterations(
-  value: number | undefined,
-  envName: string,
-): number | undefined {
-  return parsePositiveSafeInteger(value, envName);
-}
-
-export function parseMaxRetryableAttempts(
-  value: number | undefined,
-  envName: string,
-): number | undefined {
-  return parsePositiveSafeInteger(value, envName);
-}
-
-function parsePositiveSafeInteger(
   value: number | undefined,
   envName: string,
 ): number | undefined {
@@ -411,9 +343,8 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
     typeof record.chain !== "string" ||
     typeof record.privateKey !== "string" ||
     typeof record.sleepIntervalSeconds !== "number" ||
-    (record.rpcUrl !== undefined && typeof record.rpcUrl !== "string") ||
-    (record.maxIterations !== undefined && typeof record.maxIterations !== "number") ||
-    (record.maxRetryableAttempts !== undefined && typeof record.maxRetryableAttempts !== "number")
+    record.maxIterations !== undefined && typeof record.maxIterations !== "number" ||
+    record.maxRetryableAttempts !== undefined && typeof record.maxRetryableAttempts !== "number"
   ) {
     throw new Error("Invalid env " + envName);
   }
@@ -424,10 +355,10 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
   return {
     chain: record.chain,
     privateKey: parsePrivateKey(record.privateKey, envName),
-    rpcUrl: record.rpcUrl !== undefined ? parseRpcUrl(record.rpcUrl, envName) : undefined,
+    rpcUrl: parseOptionalRpcUrl(record.rpcUrl, envName),
     sleepIntervalMs: parseSleepInterval(record.sleepIntervalSeconds, envName),
     maxIterations: parseMaxIterations(record.maxIterations, envName),
-    maxRetryableAttempts: parseMaxRetryableAttempts(record.maxRetryableAttempts, envName),
+    maxRetryableAttempts: parseMaxIterations(record.maxRetryableAttempts, envName),
   };
 }
 
@@ -478,13 +409,39 @@ export async function signerAccountLocks(
   ])];
 }
 
-function errorToLog(error: unknown, secrets: SecretRedactionContext = {}): unknown {
-  return errorToLogValue(error, secrets, new WeakSet());
+export function postTransactionAccountPlainCkbBalance(
+  tx: ccc.Transaction,
+  capacityCells: readonly ccc.Cell[],
+  accountLocks: readonly ccc.Script[],
+): bigint {
+  const accountLockHexes = new Set(accountLocks.map((lock) => lock.toHex()));
+  const spentOutPoints = new Set(tx.inputs.map((input) => input.previousOutput.toHex()));
+  const unspentCapacity = capacityCells.reduce(
+    (total, cell) =>
+      spentOutPoints.has(cell.outPoint.toHex()) ||
+      !isAccountPlainCapacityOutput(cell.cellOutput, cell.outputData, accountLockHexes)
+        ? total
+        : total + cell.cellOutput.capacity,
+    0n,
+  );
+  const outputCapacity = tx.outputs.reduce(
+    (total, output, index) => total + (isAccountPlainCapacityOutput(output, tx.outputsData[index], accountLockHexes) ? output.capacity : 0n),
+    0n,
+  );
+
+  return unspentCapacity + outputCapacity;
+}
+
+function isAccountPlainCapacityOutput(output: ccc.CellOutput, outputData: string | undefined, accountLockHexes: Set<string>): boolean {
+  return output.type === undefined && (outputData ?? "0x") === "0x" && accountLockHexes.has(output.lock.toHex());
+}
+
+function errorToLog(error: unknown): unknown {
+  return errorToLogValue(error, new WeakSet());
 }
 
 function errorToLogValue(
   error: unknown,
-  secrets: SecretRedactionContext,
   seen: WeakSet<object>,
 ): unknown {
   if (error instanceof Object && "stack" in error) {
@@ -492,20 +449,22 @@ function errorToLogValue(
       return "[Circular]";
     }
     seen.add(error);
-    const stack = redactSecretText(typeof error.stack === "string" ? error.stack : "", secrets);
+    const stack = typeof error.stack === "string" ? error.stack : "";
+    const message = "message" in error && typeof error.message === "string"
+      ? error.message
+      : "Unknown error";
     const logged: Record<string, unknown> = {
+      ...errorOwnProperties(error, seen),
       name: "name" in error ? error.name : undefined,
-      message:
-        "message" in error && typeof error.message === "string"
-          ? redactSecretText(error.message, secrets)
-          : "Unknown error",
+      message,
       txHash: "txHash" in error ? error.txHash : undefined,
       status: "status" in error ? error.status : undefined,
+      isTimeout: "isTimeout" in error ? error.isTimeout : undefined,
       stack,
     };
     try {
       if ("cause" in error) {
-        logged.cause = errorToLogValue((error as { cause?: unknown }).cause, secrets, seen);
+        logged.cause = errorToLogValue((error as { cause?: unknown }).cause, seen);
       }
       return logged;
     } finally {
@@ -514,32 +473,47 @@ function errorToLogValue(
   }
 
   if (typeof error === "object" && error !== null) {
-    return sanitizeLogValue(error, secrets, new WeakSet());
+    return toJsonLogValue(error, seen);
   }
 
   if (typeof error === "string") {
-    return redactSecretText(error, secrets);
+    return error;
   }
 
   return error ?? "Empty Error";
 }
 
-function sanitizeLogValue(
+const ERROR_BUILTIN_KEYS = new Set(["name", "message", "stack", "cause"]);
+
+function errorOwnProperties(error: object, seen: WeakSet<object>): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(error)) {
+    if (ERROR_BUILTIN_KEYS.has(key)) {
+      continue;
+    }
+    properties[key] = toJsonLogValue(entry, seen);
+  }
+  return properties;
+}
+
+function toJsonLogValue(
   value: unknown,
-  secrets: SecretRedactionContext,
   seen: WeakSet<object>,
 ): unknown {
   if (typeof value === "string") {
-    return redactSecretText(value, secrets);
+    return value;
   }
   if (typeof value === "bigint") {
     return value.toString();
+  }
+  if (typeof value === "function") {
+    return UNSAFE_LOG_VALUE;
   }
   if (typeof value !== "object" || value === null) {
     return value;
   }
   if (value instanceof Object && "stack" in value) {
-    return errorToLogValue(value, secrets, seen);
+    return errorToLogValue(value, seen);
   }
   if (seen.has(value)) {
     return "[Circular]";
@@ -547,26 +521,16 @@ function sanitizeLogValue(
   seen.add(value);
   try {
     if (Array.isArray(value)) {
-      return value.map((entry) => sanitizeLogValue(entry, secrets, seen));
+      return value.map((entry) => toJsonLogValue(entry, seen));
     }
     const sanitized: Record<string, unknown> = {};
     for (const [key, entry] of Object.entries(value)) {
-      if (isSensitiveLogKey(key)) {
-        continue;
-      }
-      sanitized[key] = sanitizeLogValue(entry, secrets, seen);
+      sanitized[key] = toJsonLogValue(entry, seen);
     }
     return sanitized;
   } finally {
     seen.delete(value);
   }
-}
-
-function isSensitiveLogKey(key: string): boolean {
-  const normalized = key.toLowerCase().replace(/[-_]/gu, "");
-  return ["privatekey", "rpcurl", "apikey", "password", "token", "secret"].some(
-    (sensitiveKey) => normalized === sensitiveKey || normalized.endsWith(sensitiveKey),
-  );
 }
 
 function shouldStopAfterError(error: unknown): boolean {
@@ -579,9 +543,8 @@ function shouldStopAfterError(error: unknown): boolean {
 export function handleLoopError(
   executionLog: Record<string, unknown>,
   error: unknown,
-  secrets: SecretRedactionContext = {},
 ): boolean {
-  executionLog.error = errorToLog(error, secrets);
+  executionLog.error = errorToLog(error);
   if (shouldStopAfterError(error)) {
     process.exitCode = STOP_EXIT_CODE;
     return true;
@@ -601,7 +564,7 @@ export function logExecution(
 }
 
 export function writeJsonLine(record: unknown): void {
-  process.stdout.write(`${JSON.stringify(record, jsonLogReplacer)}\n`);
+  process.stdout.write(`${JSON.stringify(toJsonLogValue(record, new WeakSet()), jsonLogReplacer)}\n`);
 }
 
 export function sleep(ms: number): Promise<void> {

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -222,12 +222,12 @@ export function isRetryableCkbStateRaceError(error: unknown): boolean {
   if (typeof code !== "number" || typeof data !== "string") {
     return false;
   }
-  return code === -1111 && data.includes("RBFRejected(") ||
-    code === -301 && (
+  return (code === -1111 && data.includes("RBFRejected(")) ||
+    (code === -301 && (
       data.includes("Resolve(Unknown(OutPoint(") ||
       data.includes("Resolve(Dead(OutPoint(")
-    ) ||
-    code === -1107 && data.includes("Duplicated(Byte32(");
+    )) ||
+    (code === -1107 && data.includes("Duplicated(Byte32("));
 }
 
 export function parseSleepInterval(

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -139,8 +139,21 @@ export async function verifyChainPreflight(
         cause: { name: "TypeError", message: "fetch failed" },
       });
     }
-    throw new Error(`Failed to verify ${chain} RPC chain identity`);
+    throw new Error(`Failed to verify ${chain} RPC chain identity`, {
+      cause: safePreflightFailureCause(error),
+    });
   }
+}
+
+function safePreflightFailureCause(error: unknown): { name: string } | { type: string } {
+  if (error instanceof Error) {
+    return { name: safeErrorName(error.name) };
+  }
+  return { type: error === null ? "null" : typeof error };
+}
+
+function safeErrorName(name: string): string {
+  return /^[A-Za-z][\w.-]{0,63}$/u.test(name) ? name : "Error";
 }
 
 function isPublicChainPreflightFailure(error: unknown, chain: SupportedChain): boolean {
@@ -357,8 +370,8 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
     typeof record.chain !== "string" ||
     typeof record.privateKey !== "string" ||
     typeof record.sleepIntervalSeconds !== "number" ||
-    record.maxIterations !== undefined && typeof record.maxIterations !== "number" ||
-    record.maxRetryableAttempts !== undefined && typeof record.maxRetryableAttempts !== "number"
+    (record.maxIterations !== undefined && typeof record.maxIterations !== "number") ||
+    (record.maxRetryableAttempts !== undefined && typeof record.maxRetryableAttempts !== "number")
   ) {
     throw new Error("Invalid env " + envName);
   }

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -553,6 +553,9 @@ function toJsonLogValue(
   if (typeof value !== "object" || value === null) {
     return value;
   }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
   if (value instanceof Object && "stack" in value) {
     return errorToLogValue(value, seen);
   }

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -289,6 +289,20 @@ export function parseMaxIterations(
   value: number | undefined,
   envName: string,
 ): number | undefined {
+  return parsePositiveIntegerLimit(value, envName);
+}
+
+function parseMaxRetryableAttempts(
+  value: number | undefined,
+  envName: string,
+): number | undefined {
+  return parsePositiveIntegerLimit(value, envName);
+}
+
+function parsePositiveIntegerLimit(
+  value: number | undefined,
+  envName: string,
+): number | undefined {
   if (value === undefined) {
     return;
   }
@@ -358,7 +372,7 @@ export function parseRuntimeConfig(configText: string, envName: string): Runtime
     rpcUrl: parseOptionalRpcUrl(record.rpcUrl, envName),
     sleepIntervalMs: parseSleepInterval(record.sleepIntervalSeconds, envName),
     maxIterations: parseMaxIterations(record.maxIterations, envName),
-    maxRetryableAttempts: parseMaxIterations(record.maxRetryableAttempts, envName),
+    maxRetryableAttempts: parseMaxRetryableAttempts(record.maxRetryableAttempts, envName),
   };
 }
 

--- a/scripts/ickb-live-preflight.mjs
+++ b/scripts/ickb-live-preflight.mjs
@@ -51,13 +51,12 @@ export function publicScript(script) {
   };
 }
 
-export function redactErrorMessage(error, secrets = {}) {
-  let message = error instanceof Error ? error.message : String(error ?? "Unknown error");
-  if (secrets.privateKey) {
-    message = message.split(secrets.privateKey).join("<redacted-private-key>");
-  }
-  message = secrets.redactSecretText?.(message, secrets) ?? message;
-  return message;
+export function publicErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error ?? "Unknown error");
+}
+
+export function isPublicChainIdentityError(error) {
+  return error instanceof Error && error.message.includes("Invalid") && error.message.includes("chain identity");
 }
 
 export function ckbReserveForRole(role) {
@@ -94,13 +93,6 @@ export async function runPreflight({ configPath, role, root = rootDir, dependenc
     core,
   } = dependencies ?? await loadBuiltStack(root);
 
-  const secrets = {
-    privateKey: runtimeConfig.privateKey,
-    rpcUrl: runtimeConfig.rpcUrl,
-    redactedRpcUrl: runtimeConfig.rpcUrl === undefined ? undefined : nodeUtils.redactRpcUrl(runtimeConfig.rpcUrl),
-    redactSecretText: nodeUtils.redactSecretText,
-  };
-
   try {
     return await buildPreflightReport({
       runtimeConfig,
@@ -111,7 +103,18 @@ export async function runPreflight({ configPath, role, root = rootDir, dependenc
       core,
     });
   } catch (error) {
-    throw new Error(redactErrorMessage(error, secrets));
+    const retryable = nodeUtils.isRetryableRpcTransportError?.(error) === true;
+    const preflightError = new Error(
+      retryable
+        ? "fetch failed"
+        : isPublicChainIdentityError(error)
+          ? error.message
+          : "Live preflight failed",
+    );
+    if (retryable) {
+      preflightError.name = "RetryablePreflightError";
+    }
+    throw preflightError;
   }
 }
 
@@ -212,7 +215,7 @@ export async function main(argv, io = {}) {
   try {
     args = parseArgs(argv);
   } catch (error) {
-    stderr.write(`${redactErrorMessage(error)}\n${usage()}\n`);
+    stderr.write(`${publicErrorMessage(error)}\n${usage()}\n`);
     return 1;
   }
   if (args.help) {
@@ -228,7 +231,10 @@ export async function main(argv, io = {}) {
     stdout.write(`${JSON.stringify(report, jsonLogReplacer, 2)}\n`);
     return 0;
   } catch (error) {
-    stderr.write(`Live preflight failed: ${redactErrorMessage(error)}\n`);
+    const label = error instanceof Error && error.name === "RetryablePreflightError"
+      ? "Live preflight retryable failure"
+      : "Live preflight failed";
+    stderr.write(`${label}: ${publicErrorMessage(error)}\n`);
     return 1;
   }
 }

--- a/scripts/ickb-live-preflight.mjs
+++ b/scripts/ickb-live-preflight.mjs
@@ -57,8 +57,8 @@ export function publicErrorMessage(error) {
 
 export function isPublicChainIdentityError(error) {
   return error instanceof Error && (
-    error.message.includes("Missing") && error.message.includes("genesis header") ||
-    error.message.includes("Invalid") && error.message.includes("chain identity")
+    (error.message.includes("Missing") && error.message.includes("genesis header")) ||
+    (error.message.includes("Invalid") && error.message.includes("chain identity"))
   );
 }
 

--- a/scripts/ickb-live-preflight.mjs
+++ b/scripts/ickb-live-preflight.mjs
@@ -56,7 +56,10 @@ export function publicErrorMessage(error) {
 }
 
 export function isPublicChainIdentityError(error) {
-  return error instanceof Error && error.message.includes("Invalid") && error.message.includes("chain identity");
+  return error instanceof Error && (
+    error.message.includes("Missing") && error.message.includes("genesis header") ||
+    error.message.includes("Invalid") && error.message.includes("chain identity")
+  );
 }
 
 export function ckbReserveForRole(role) {

--- a/scripts/ickb-live-preflight.mjs
+++ b/scripts/ickb-live-preflight.mjs
@@ -147,7 +147,8 @@ export async function buildPreflightReport({
   const depositCapacity = core.convert(false, core.ICKB_DEPOSIT_CAP, exchangeRatio);
   const minimumCkbCapital = (21n * depositCapacity) / 20n;
   const ckbReserve = ckbReserveForRole(role);
-  const spendableCkb = maxBigInt(0n, projection.ckbAvailable - ckbReserve);
+  const plainCkb = nodeUtils.accountPlainCkbBalance(account.capacityCells, accountLocks);
+  const spendableCkb = maxBigInt(0n, plainCkb - ckbReserve);
   const totalEquivalentCkb = totalCkb + core.convert(false, projection.ickbAvailable, exchangeRatio);
   const totalEquivalentIckb = core.convert(true, totalCkb, exchangeRatio) + projection.ickbAvailable;
 
@@ -167,7 +168,7 @@ export async function buildPreflightReport({
     },
     balances: {
       CKB: {
-        available: nodeUtils.formatCkb(projection.ckbAvailable),
+        available: nodeUtils.formatCkb(plainCkb),
         reserve: nodeUtils.formatCkb(ckbReserve),
         spendable: nodeUtils.formatCkb(spendableCkb),
         unavailable: nodeUtils.formatCkb(projection.ckbPending),

--- a/scripts/ickb-live-preflight.test.mjs
+++ b/scripts/ickb-live-preflight.test.mjs
@@ -125,8 +125,9 @@ test("preflight reports CKB reserve and spendable balance separately", async () 
     }));
 
     const dependencies = mockDependencies({
+      plainCkbBalance: 150000000000n,
       projection: {
-        ckbAvailable: 150000000000n,
+        ckbAvailable: 190000000000n,
         ckbPending: 25000000000n,
         ickbAvailable: 20000000000n,
         readyWithdrawals: [],
@@ -145,9 +146,9 @@ test("preflight reports CKB reserve and spendable balance separately", async () 
       reserve: "100000000000",
       spendable: "50000000000",
       unavailable: "25000000000",
-      total: "175000000000",
+      total: "215000000000",
     });
-    assert.equal(report.capital.totalEquivalentCkb, "195000000000");
+    assert.equal(report.capital.totalEquivalentCkb, "235000000000");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -166,8 +167,9 @@ test("preflight reports tester reserve and spendable balance separately", async 
     }));
 
     const dependencies = mockDependencies({
+      plainCkbBalance: 250000000000n,
       projection: {
-        ckbAvailable: 250000000000n,
+        ckbAvailable: 280000000000n,
         ckbPending: 25000000000n,
         ickbAvailable: 20000000000n,
         readyWithdrawals: [],
@@ -186,7 +188,7 @@ test("preflight reports tester reserve and spendable balance separately", async 
       reserve: "200000000000",
       spendable: "50000000000",
       unavailable: "25000000000",
-      total: "275000000000",
+      total: "305000000000",
     });
   } finally {
     await rm(dir, { recursive: true, force: true });
@@ -478,6 +480,7 @@ function mockDependencies(options = {}) {
     }),
     isRetryableRpcTransportError: () => false,
     signerAccountLocks: async (_signer, primaryLock) => [primaryLock],
+    accountPlainCkbBalance: () => options.plainCkbBalance ?? 0n,
     formatCkb: (value) => value.toString(),
   };
   const primaryLock = {
@@ -501,7 +504,7 @@ function mockDependencies(options = {}) {
       getConfig: () => ({}),
       IckbSdk: {
         fromConfig: () => ({
-          getAccountState: async () => ({ receipts: [], withdrawalGroups: [] }),
+          getAccountState: async () => ({ capacityCells: [], receipts: [], withdrawalGroups: [] }),
         }),
       },
       projectAccountAvailability: () => ({

--- a/scripts/ickb-live-preflight.test.mjs
+++ b/scripts/ickb-live-preflight.test.mjs
@@ -6,9 +6,10 @@ import { join } from "node:path";
 import test from "node:test";
 import {
   ckbReserveForRole,
+  isPublicChainIdentityError,
   parseArgs,
   publicScript,
-  redactErrorMessage,
+  publicErrorMessage,
   runPreflight,
   usage,
 } from "./ickb-live-preflight.mjs";
@@ -41,27 +42,14 @@ test("preflight CLI exposes public script shape only", () => {
   });
 });
 
-test("preflight CLI redacts private key and RPC URL in errors", () => {
-  const privateKey = `0x${"11".repeat(32)}`;
-  const rpcUrl = "https://user:pass@testnet.example/path?token=secret";
-  const redacted = "https://redacted:redacted@testnet.example/...?token=redacted";
-  const error = new Error(`failed with ${privateKey} using ${rpcUrl} user pass secret`);
-
-  const message = redactErrorMessage(error, {
-    privateKey,
-    rpcUrl,
-    redactedRpcUrl: redacted,
-    redactSecretText,
-  });
-
+test("preflight CLI keeps public error messages and classifies chain identity errors", () => {
+  assert.equal(publicErrorMessage(new Error("public failure")), "public failure");
+  assert.equal(publicErrorMessage(undefined), "Unknown error");
   assert.equal(
-    message,
-    `failed with <redacted-private-key> using ${redacted} ` +
-      "<redacted-rpc-username> <redacted-rpc-password> <redacted-rpc-query>",
+    isPublicChainIdentityError(new Error("Invalid testnet RPC chain identity: genesis hash expected 0x1 observed 0x2")),
+    true,
   );
-  assert.doesNotMatch(message, /0x11/u);
-  assert.doesNotMatch(message, /secret/u);
-  assert.doesNotMatch(message, /\buser\b|\bpass\b/u);
+  assert.equal(isPublicChainIdentityError(new Error("Invalid private key")), false);
 });
 
 test("preflight CLI exposes role-specific CKB reserves", () => {
@@ -101,7 +89,6 @@ test("preflight run reports public evidence for a generated unfunded key", async
     assert.equal(report.maxIterations, 1);
     assert.equal(report.maxRetryableAttempts, 3);
     assert.equal(report.rpcConfigured, true);
-    assert.equal(report.chainIdentity.redactedRpcUrl, "https://redacted:redacted@testnet.example/...?token=redacted");
     assert.equal(report.chainIdentity.matches.genesisHash, true);
     assert.equal(report.key.recommendedAddress, "ckt1generatedoffline");
     assert.deepEqual(report.key.primaryLock, {
@@ -314,6 +301,80 @@ test("preflight preserves parse failure cause without leaking config contents", 
   }
 });
 
+test("preflight marks retryable transport failures without leaking RPC URLs", async () => {
+  const privateKey = `0x${randomBytes(32).toString("hex")}`;
+  const dir = await mkdtemp(join(tmpdir(), "ickb-live-preflight-"));
+  try {
+    const configPath = join(dir, "config.json");
+    await writeFile(configPath, JSON.stringify({
+      chain: "testnet",
+      privateKey,
+      rpcUrl: "https://testnet.example/path?token=secret",
+      sleepIntervalSeconds: 1,
+      maxIterations: 1,
+    }));
+    const dependencies = mockDependencies();
+    const fetchFailure = new TypeError("fetch failed");
+    dependencies.nodeUtils.verifyChainPreflight = async () => {
+      throw fetchFailure;
+    };
+    dependencies.nodeUtils.isRetryableRpcTransportError = (error) => error === fetchFailure;
+
+    await assert.rejects(
+      () => runPreflight({
+        configPath,
+        role: "bot",
+        root: dir,
+        dependencies: { ...dependencies, checkIgnored: () => true },
+      }),
+      (error) => {
+        assert(error instanceof Error);
+        assert.equal(error.name, "RetryablePreflightError");
+        assert.equal(error.message, "fetch failed");
+        assert.doesNotMatch(error.message, /token=secret/u);
+        return true;
+      },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("preflight preserves public wrong-chain evidence for supervisor classification", async () => {
+  const privateKey = `0x${randomBytes(32).toString("hex")}`;
+  const dir = await mkdtemp(join(tmpdir(), "ickb-live-preflight-"));
+  try {
+    const configPath = join(dir, "config.json");
+    await writeFile(configPath, JSON.stringify({
+      chain: "testnet",
+      privateKey,
+      sleepIntervalSeconds: 1,
+      maxIterations: 1,
+    }));
+    const dependencies = mockDependencies();
+    dependencies.nodeUtils.verifyChainPreflight = async () => {
+      throw new Error("Invalid testnet RPC chain identity: genesis hash expected 0x1 observed 0x2");
+    };
+
+    await assert.rejects(
+      () => runPreflight({
+        configPath,
+        role: "bot",
+        root: dir,
+        dependencies: { ...dependencies, checkIgnored: () => true },
+      }),
+      (error) => {
+        assert(error instanceof Error);
+        assert.equal(error.message, "Invalid testnet RPC chain identity: genesis hash expected 0x1 observed 0x2");
+        assert.doesNotMatch(error.message, new RegExp(privateKey, "u"));
+        return true;
+      },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("preflight refuses non-ignored and out-of-repo config paths", async () => {
   const dir = await mkdtemp(join(tmpdir(), "ickb-live-preflight-"));
   try {
@@ -396,8 +457,6 @@ function mockDependencies(options = {}) {
         maxRetryableAttempts: parsed.maxRetryableAttempts,
       };
     },
-    redactRpcUrl: () => "https://redacted:redacted@testnet.example/...?token=redacted",
-    redactSecretText,
     createPublicClient: (chain, rpcUrl) => {
       options.createPublicClientCalls?.push({ chain, rpcUrl });
       return {
@@ -409,7 +468,6 @@ function mockDependencies(options = {}) {
     },
     verifyChainPreflight: async () => ({
       chain: "testnet",
-      redactedRpcUrl: "https://redacted:redacted@testnet.example/...?token=redacted",
       expected: { genesisHash: expectedGenesis, addressPrefix: "ckt" },
       observed: {
         genesisHash: expectedGenesis,
@@ -418,6 +476,7 @@ function mockDependencies(options = {}) {
       },
       matches: { genesisHash: true, addressPrefix: true },
     }),
+    isRetryableRpcTransportError: () => false,
     signerAccountLocks: async (_signer, primaryLock) => [primaryLock],
     formatCkb: (value) => value.toString(),
   };
@@ -461,21 +520,6 @@ function mockDependencies(options = {}) {
       convert: (_toIckb, value) => value,
     },
   };
-}
-
-function redactSecretText(text, secrets = {}) {
-  let redacted = text;
-  if (secrets.privateKey) {
-    redacted = redacted.split(secrets.privateKey).join("<redacted-private-key>");
-  }
-  if (secrets.rpcUrl) {
-    redacted = redacted
-      .split(secrets.rpcUrl).join(secrets.redactedRpcUrl)
-      .split("user").join("<redacted-rpc-username>")
-      .split("pass").join("<redacted-rpc-password>")
-      .split("secret").join("<redacted-rpc-query>");
-  }
-  return redacted;
 }
 
 function bigintReplacer(_key, value) {

--- a/scripts/ickb-live-preflight.test.mjs
+++ b/scripts/ickb-live-preflight.test.mjs
@@ -49,6 +49,7 @@ test("preflight CLI keeps public error messages and classifies chain identity er
     isPublicChainIdentityError(new Error("Invalid testnet RPC chain identity: genesis hash expected 0x1 observed 0x2")),
     true,
   );
+  assert.equal(isPublicChainIdentityError(new Error("Missing testnet genesis header")), true);
   assert.equal(isPublicChainIdentityError(new Error("Invalid private key")), false);
 });
 


### PR DESCRIPTION
## Why
The bot needs public evidence to distinguish retryable RPC/CKB state races, reserve skips, and terminal failures without passing signing material or credentialed RPC URLs through logger/redaction helpers.

## Changes
- Add chain preflight, retryability, transaction lifecycle, match/rebalance, and reserve-skip evidence to bot structured events.
- Move retry classification, safe preflight failure surfaces, JSON-safe error logging, and post-transaction plain CKB accounting into node-utils.
- Update tester and live preflight call sites to follow the secret boundary and stop passing secret context into logging paths.