### PR TITLE
fix(tester): skip initial live sleep

### DIFF
--- a/apps/tester/README.md
+++ b/apps/tester/README.md
@@ -41,7 +41,7 @@ export TESTER_CONFIG_FILE="$(pwd)/../../config/tester-testnet.json"
 pnpm run start
 ```
 
-The start script writes one newline-delimited JSON log stream per run. Each loop appends one JSON object to the log file. Balance, amount, and fee values are decimal strings so bigint values do not lose precision. Confirmation timeouts are logged with the broadcast hash and stop the loop with exit code `2` so a wrapper does not immediately send conflicting replacement work.
+The start script writes one newline-delimited JSON log stream per run. Each loop appends one JSON object to the log file. On startup the tester attempts one iteration immediately; the configured sleep applies only between completed iterations. Balance, amount, and fee values are decimal strings so bigint values do not lose precision. Confirmation timeouts are logged with the broadcast hash and stop the loop with exit code `2` so a wrapper does not immediately send conflicting replacement work.
 
 ## Test Scenarios
 

--- a/apps/tester/README.md
+++ b/apps/tester/README.md
@@ -41,7 +41,7 @@ export TESTER_CONFIG_FILE="$(pwd)/../../config/tester-testnet.json"
 pnpm run start
 ```
 
-The start script writes one newline-delimited JSON log stream per run. Each loop appends one JSON object to the log file. On startup the tester attempts one iteration immediately; the configured sleep applies only between completed iterations. Balance, amount, and fee values are decimal strings so bigint values do not lose precision. Confirmation timeouts are logged with the broadcast hash and stop the loop with exit code `2` so a wrapper does not immediately send conflicting replacement work.
+The start script writes one newline-delimited JSON log stream per run. Each loop appends one JSON object to the log file. On startup the tester attempts one iteration immediately; the configured sleep applies before subsequent attempts. Balance, amount, and fee values are decimal strings so bigint values do not lose precision. Confirmation timeouts are logged with the broadcast hash and stop the loop with exit code `2` so a wrapper does not immediately send conflicting replacement work.
 
 ## Test Scenarios
 

--- a/apps/tester/src/index.test.ts
+++ b/apps/tester/src/index.test.ts
@@ -17,6 +17,7 @@ import {
   readTesterFeePolicy,
   readTesterRuntimeConfig,
   readTesterScenario,
+  shouldSleepBeforeTesterAttempt,
   testerAttemptedTransactionEvidence,
   testerEstimatedTooSmallSkip,
   testerExecutionActions,
@@ -157,6 +158,13 @@ describe("isUnrepresentableTesterEstimateError", () => {
   it("recognizes fee-adjusted ratio overflow as an unbuildable tester estimate", () => {
     expect(isUnrepresentableTesterEstimateError(new Error("Ratio scale exceeds Uint64"))).toBe(true);
     expect(isUnrepresentableTesterEstimateError(new Error("L1 state scan crossed chain tip; retry with a fresh state"))).toBe(false);
+  });
+});
+
+describe("shouldSleepBeforeTesterAttempt", () => {
+  it("runs the first attempt immediately and sleeps before later attempts", () => {
+    expect(shouldSleepBeforeTesterAttempt(0)).toBe(false);
+    expect(shouldSleepBeforeTesterAttempt(1)).toBe(true);
   });
 });
 

--- a/apps/tester/src/index.ts
+++ b/apps/tester/src/index.ts
@@ -122,13 +122,17 @@ async function main(): Promise<void> {
     accountLocks: await signerAccountLocks(signer, primaryLock),
   };
 
-  let stopAfterLog = false;
+  let startedAttempts = 0;
   let completedIterations = 0;
   for (;;) {
-    await sleep(randomSleepIntervalMs(sleepIntervalMs));
+    if (shouldSleepBeforeTesterAttempt(startedAttempts)) {
+      await sleep(randomSleepIntervalMs(sleepIntervalMs));
+    }
+    startedAttempts += 1;
 
     const executionLog: Record<string, unknown> = {};
     const startTime = new Date();
+    let stopAfterLog = false;
     executionLog.startTime = startTime.toLocaleString();
 
     try {
@@ -279,6 +283,10 @@ async function main(): Promise<void> {
       return;
     }
   }
+}
+
+export function shouldSleepBeforeTesterAttempt(startedAttempts: number): boolean {
+  return startedAttempts > 0;
 }
 
 function logTerminalIteration(


### PR DESCRIPTION
## Why
Live tester runs currently wait for the randomized sleep interval before the first attempt. Bounded supervisor/testnet runs should produce an immediate first observation, then keep sleeping between later attempts.

## Changes
- Skip the configured sleep before the first tester attempt.
- Keep sleeping before subsequent attempts, including retryable error attempts.
- Document the startup timing behavior in the tester README.