### PR TITLE
Add live supervisor evidence loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Artifacts
 **/dist/
+log/
 apps/*/log_*.json
 
 # Local runtime config files

--- a/README.md
+++ b/README.md
@@ -105,19 +105,31 @@ pnpm --filter @ickb/supervisor build
 pnpm live:supervisor
 ```
 
-To rebuild the standard ignored testnet configs from environment variables without printing private keys, set `ICKB_TESTNET_BOT_PRIVATE_KEY` and `ICKB_TESTNET_TESTER_PRIVATE_KEY`, optionally set `ICKB_TESTNET_RPC_URL`, `ICKB_TESTNET_SLEEP_INTERVAL_SECONDS`, `ICKB_TESTNET_MAX_ITERATIONS`, and `ICKB_TESTNET_MAX_RETRYABLE_ATTEMPTS`, then run:
+By default the supervisor uses ignored `config/bot-testnet.json` and `config/tester-testnet.json`, writes standalone artifacts under ignored `logs/live-supervisor/<run-id>/` paths, and runs deterministic bounded bot/tester commands only. It does not patch, verify, rebuild, relaunch, or invoke an LLM; external loops and operators consume `summary.json` between runs.
 
-```bash
-pnpm live:config-from-env
-```
-
-By default the supervisor uses ignored `config/bot-testnet.json` and `config/tester-testnet.json`, writes artifacts under ignored `logs/live-supervisor/<run-id>/` paths, and runs deterministic bounded bot/tester commands only. It does not patch, verify, rebuild, relaunch, or invoke an LLM; external loops and operators consume `summary.json` between runs.
+`pnpm live:preflight -- --config config/bot-testnet.json --role bot` prints public balance evidence for funding checks. Check `balances.CKB.available` together with `balances.CKB.reserve`, `balances.CKB.spendable`, and `capital.minimumCkbCapital`; raw available CKB is not the same as bot-spendable CKB.
 
 For repeated bounded invocations, keep loop-owned options before `--` and supervisor options after it:
 
 ```bash
-pnpm live:supervisor:loop -- --scenario standard-cycle --max-cycles 1
+pnpm live:supervisor:loop --max-runs 1 -- --scenario standard-cycle --max-cycles 1
 ```
+
+Use loop-owned `--child-timeout-seconds` to bound the outer supervisor child process when running long watches; keep it long enough for the whole supervisor invocation, including actor preflights and actor commands, so the supervisor remains alive to enforce its own `--command-timeout-seconds` process-group cleanup.
+
+For continuous live matching, use the dynamic external loop. It reads only tester preflight balance summaries, chooses a fundable tester stimulus (`all-ckb-limit-order` when plain CKB can preserve reserve plus overhead, otherwise `ickb-to-ckb-limit-order` with the smaller live fee when iCKB is available), then runs bounded `scripts/ickb-supervisor-loop.mjs` chunks:
+
+```bash
+pnpm live:supervisor:dynamic-loop
+```
+
+Dynamic validation sessions default to ignored `log/validation/dynamic-<time>-<pid>/` under the checkout. Override the root with `--log-root <path>` or pin a single session with `--session-root <path>`; the session root must be exactly `<log-root>/validation/<session>`, stay under the resolved log root, avoid symlinked parents, and be new for each run. Loop-owned options stay before `--`, while supervisor options stay after it. The dynamic loop derives `--chunk-timeout-seconds` from its delegated supervisor-loop child timeout, chunk run count, and chunk backoff so the outer chunk timeout does not preempt supervisor-owned child cleanup:
+
+```bash
+pnpm live:supervisor:dynamic-loop --log-root log --max-chunks 2 -- --target-outcome bot_match_committed
+```
+
+Session layout is source-separated: `operator/events.ndjson`, `operator/launch.json`, optional `operator/stderr.log`, and `chunks/chunk-0001/run-0001/summary.json` plus the supervisor-owned preflight, bot, tester, and supervisor artifacts.
 
 Explicit repeatable `--target-outcome` requests become bounded coverage contracts: if `--max-cycles` ends before they are observed, the supervisor writes a logical incident for external review. The supervisor treats public testnet iCKB deposits, receipts, and orders as observable stress surface, but only bot/tester-owned state from the supplied configs is treated as spend authority.
 

--- a/apps/supervisor/README.md
+++ b/apps/supervisor/README.md
@@ -20,19 +20,22 @@ Run from the repo root:
 pnpm live:supervisor
 ```
 
-By default this uses `config/bot-testnet.json` and `config/tester-testnet.json`. Configs must be ignored JSON files and should keep `maxIterations: 1`. The supervisor passes config paths to the existing app env names and does not print config contents.
+By default this uses `config/bot-testnet.json` and `config/tester-testnet.json`. Configs must be ignored JSON files with `maxIterations: 1`; the supervisor refuses to launch an actor when preflight reports the config is missing that one-iteration bound. The supervisor passes config paths to the existing app env names and does not print config contents.
 
 ## Artifacts
 
-Default artifacts live under `logs/live-supervisor/<run-id>/`, which is ignored by git. Each run writes:
+Standalone supervisor artifacts live under `logs/live-supervisor/<run-id>/`, which is ignored by git. Each run writes:
 
 - `supervisor.ndjson`: concise supervisor events.
-- `cycle-<n>-<actor>.stdout.ndjson` and `.stderr.log`: bounded app-process evidence for that actor.
-- `cycle-<n>-<actor>.command.json`: redacted command shape and exit status.
+- `cycle-<n>-<actor>.stdout.ndjson` and `.stderr.log`: bounded raw bot/tester app-process evidence for that actor.
+- `cycle-<n>-<actor>-preflight.stdout.json` and `.stderr.log`: bounded public preflight evidence for that actor. Preflight stdout is one pretty JSON report, not NDJSON.
+- `cycle-<n>-<actor>.command.json`: command shape and exit status.
 - `cycle-<n>-incident.json`: written only on unknown, unsafe, unsupported, or unmet explicit coverage outcomes.
-- `summary.json`: aggregate outcomes, coverage ledger, tx hashes by outcome, and public-vs-owned state assumptions.
+- `summary.json`: aggregate outcomes, safe preflight balance and tester-steering summaries, coverage ledger, tx hashes by outcome, and public-vs-owned state assumptions.
 
 The supervisor treats public testnet iCKB deposits, receipts, and orders as observable scenario surface. It does not count public state as bot/tester-owned inventory or as permission to mutate unrelated cells.
+
+Actor artifacts preserve debugging evidence, including public chain/RPC identity evidence and raw transaction-shaped fields such as `inputs`, `outputs`, `cellDeps`, `headerDeps`, `outputsData`, and `witnesses`. Captured bot stdout remains the canonical bot NDJSON stream with `app: "bot"` and `bot.*` event semantics unchanged; validation context belongs in supervisor/operator summaries, not rewritten bot events. Bot, tester, and preflight producers own their configured private keys and must use them only for signing, never logging helpers, redaction helpers, masking callbacks, or guard utilities. If a configured key or other secret reaches supervisor capture, stop and fix that producer instead of masking and continuing.
 
 ## Scenario Coverage
 
@@ -40,7 +43,7 @@ The default planner prefers under-covered safe outcomes over repeating the same 
 
 ```bash
 --scenario auto|standard-cycle|tester-only|bot-only|tester-fresh-skip-two-pass
---tester-scenario auto|random-order|sdk-conversion|extra-large-limit-order|multi-order-limit-orders|two-ckb-to-ickb-limit-orders|all-ckb-limit-order|ickb-to-ckb-limit-order|two-ickb-to-ckb-limit-orders|mixed-direction-limit-orders|dust-ckb-conversion|dust-ickb-conversion
+--tester-scenario auto|random-order|sdk-conversion|extra-large-limit-order|multi-order-limit-orders|two-ckb-to-ickb-limit-orders|all-ckb-limit-order|ickb-to-ckb-limit-order|bounded-ickb-to-ckb-limit-order|two-ickb-to-ckb-limit-orders|mixed-direction-limit-orders|dust-ckb-conversion|dust-ickb-conversion
 --tester-fee <n>
 --tester-fee-base <n>
 --target-outcome <outcome>
@@ -48,11 +51,13 @@ The default planner prefers under-covered safe outcomes over repeating the same 
 
 Coverage goals never override stop conditions. If a requested scenario cannot be reached through safe supervisor/test-harness controls, the supervisor writes an incident instead of mutating funded configs in place or forcing tx-bearing paths.
 
-Explicit repeatable `--target-outcome` values are coverage contracts for the bounded run. If `--max-cycles` is reached before observing them, the supervisor writes a logical `unmet_coverage_goal` incident. Default coverage goals still steer the planner, but they are best-effort and do not make a bare one-cycle run fail. `--stop-after-tx-count` remains a successful operator stop even if explicit coverage remains unmet.
+Bot withdrawal-request, receipt-completion, and withdrawal-completion coverage are satisfied by any committed bot transaction whose built action evidence has `withdrawalRequests > 0`, `completedDeposits > 0`, or `withdrawals > 0`, including transactions that also match orders. `bot_match_plus_deposit_committed` remains the more specific combined match-and-deposit outcome.
+
+Explicit repeatable `--target-outcome` values are coverage contracts for the bounded run. If the bounded cycle or wall-clock budget ends before observing them, the supervisor writes a logical `unmet_coverage_goal` incident. Default coverage goals still steer the planner, but they are best-effort and do not make a bare one-cycle run fail. `--stop-after-tx-count` remains a successful operator stop even if explicit coverage remains unmet.
 
 `--tester-scenario` is passed to the tester as `TESTER_SCENARIO`. When it is left as `auto`, `--target-outcome tester_conversion_created` steers the tester to `sdk-conversion`, the SDK conversion-builder selector. Use `ickb-to-ckb-limit-order` for iCKB withdrawal-through-LO coverage. Use `sdk-conversion` when the intended behavior is the SDK conversion builder, including direct conversions that do not create limit orders, `multi-order-limit-orders` for any funded two-order raw limit-order type, `two-ckb-to-ickb-limit-orders`, `two-ickb-to-ckb-limit-orders`, or `mixed-direction-limit-orders` for a specific two-order transaction, and `extra-large-limit-order` to stress non-interface users placing large raw limit orders. An explicit `--tester-scenario` overrides target-outcome steering.
 
-`tester-fresh-skip-two-pass` runs the same tester config twice in one supervisor cycle. Pass 1 uses `multi-order-limit-orders` to create any funded multi-order transaction; pass 2 leaves `TESTER_SCENARIO=auto` and is expected to classify `tester_fresh_order_skip` when the same key still owns a fresh matchable order. Artifacts use `tester-pass-1` and `tester-pass-2` labels so the two passes do not overwrite each other.
+`tester-fresh-skip-two-pass` runs the same tester config twice in one supervisor cycle. Both passes leave `TESTER_SCENARIO=auto` unless `--tester-scenario` is explicit, so the tester selects a currently fundable first-pass order instead of forcing a CKB-heavy multi-order stimulus. Pass 2 is expected to classify `tester_fresh_order_skip` when the same key still owns a fresh matchable order. Artifacts use `tester-pass-1` and `tester-pass-2` labels so the two passes do not overwrite each other.
 
 `--tester-fee` and `--tester-fee-base` are tester-owned raw limit-order fee controls. Defaults stay `1 / 100000` (0.001%). When provided, the supervisor passes them only to the tester as `TESTER_FEE` and `TESTER_FEE_BASE`; `sdk-conversion` keeps using SDK-owned fee defaults for any order remainder.
 
@@ -66,4 +71,27 @@ The KISS watcher script runs one deterministic supervisor invocation per child o
 node scripts/ickb-supervisor-loop.mjs --max-runs 1 --stable-limit 2 --backoff-seconds 0 -- --scenario standard-cycle --max-cycles 1
 ```
 
-Loop-owned options go before `--`; supervisor options go after `--`. If using `pnpm live:supervisor:loop`, keep loop-owned options before the first `--` so they are not passed through to the supervisor. The loop stops on supervisor nonzero exit, incident artifacts listed in `summary.json`, any tx hash, a new outcome after the first run, repeated no-progress signatures, or `--max-runs`.
+Loop-owned options go before `--`; supervisor options go after `--`. If using `pnpm live:supervisor:loop`, keep loop-owned options before the first `--` so they are not passed through to the supervisor. The loop stops on supervisor nonzero exit, incident artifacts listed in `summary.json`, tx-creating outcomes or tx hashes for tx-creating outcomes, a new outcome after the first run, repeated no-progress signatures, or `--max-runs`.
+
+The external loop also has a loop-owned `--child-timeout-seconds` guard for the supervisor child process. Keep it long enough for the whole delegated supervisor run, including actor preflights and actor commands, not just one `--command-timeout-seconds` window. The dynamic loop defaults this guard to the supervisor-loop default so the supervisor keeps ownership of killing funded actor process groups on command timeout.
+
+For continuous tester-bot matching, use `node scripts/ickb-supervisor-dynamic-loop.mjs` or `pnpm live:supervisor:dynamic-loop`. This remains outside `apps/supervisor`: it reads tester preflight balance summaries, chooses a currently fundable tester scenario, and delegates each bounded chunk to `scripts/ickb-supervisor-loop.mjs`. When `--target-outcome tester_fresh_order_skip` is passed through, supervisor auto-planning can choose `tester-fresh-skip-two-pass`; the dynamic loop itself only chooses fundable tester stimuli.
+
+Dynamic loop sessions are live-validation artifacts. They default to ignored `log/validation/dynamic-<time>-<pid>/`; override the root with `--log-root <path>` or pin one run with `--session-root <path>`. The session root must be exactly `<log-root>/validation/<session>`, stay under the resolved log root, avoid symlinked parents, and not already exist. The dynamic loop derives its chunk timeout from the delegated supervisor-loop child timeout, chunk run count, and chunk backoff unless `--chunk-timeout-seconds` is explicitly set high enough, so an outer chunk timeout does not kill the supervisor-loop process before it can enforce its child cleanup boundary.
+
+```bash
+node scripts/ickb-supervisor-dynamic-loop.mjs --log-root log --max-chunks 2 -- --target-outcome bot_match_committed
+```
+
+The dynamic loop writes operator records under the session and passes each chunk root to `scripts/ickb-supervisor-loop.mjs` as loop-owned `--out-root` before `--`:
+
+```text
+<log-root>/validation/dynamic-<time>-<pid>/
+  operator/events.ndjson
+  operator/launch.json
+  operator/stderr.log (only when child stderr is captured)
+  chunks/chunk-0001/run-0001/summary.json
+  chunks/chunk-0001/run-0001/supervisor.ndjson
+  chunks/chunk-0001/run-0001/cycle-0001-bot.stdout.ndjson
+  chunks/chunk-0001/run-0001/cycle-0001-tester.stdout.ndjson
+```

--- a/apps/supervisor/src/index.test.ts
+++ b/apps/supervisor/src/index.test.ts
@@ -13,7 +13,6 @@ import {
   recordScenarioAttempt,
   recordOutcome,
   resolvePlan,
-  safeArtifactText,
   supervise,
   usage,
   type CommandResult,
@@ -62,6 +61,9 @@ describe("supervisor CLI", () => {
     expect(parseArgs(["--tester-scenario", "two-ickb-to-ckb-limit-orders"]).testerScenario).toBe(
       "two-ickb-to-ckb-limit-orders",
     );
+    expect(parseArgs(["--tester-scenario", "bounded-ickb-to-ckb-limit-order"]).testerScenario).toBe(
+      "bounded-ickb-to-ckb-limit-order",
+    );
     expect(parseArgs(["--tester-scenario", "mixed-direction-limit-orders"]).testerScenario).toBe(
       "mixed-direction-limit-orders",
     );
@@ -103,7 +105,7 @@ describe("supervisor CLI", () => {
     const args = parseArgs(["--dry-run", "--out-dir", "not-ignored"]);
 
     expect(() => resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(false) })).toThrow(
-      "Supervisor output directory must be under logs/live-supervisor/",
+      "Supervisor output directory must be under logs/live-supervisor/ or a validation session run directory",
     );
   });
 
@@ -111,7 +113,7 @@ describe("supervisor CLI", () => {
     const args = parseArgs(["--dry-run", "--out-dir", "config/supervisor"]);
 
     expect(() => resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) })).toThrow(
-      "Supervisor output directory must be under logs/live-supervisor/",
+      "Supervisor output directory must be under logs/live-supervisor/ or a validation session run directory",
     );
   });
 
@@ -122,6 +124,50 @@ describe("supervisor CLI", () => {
     expect(plan.relativeOutDir).toBe("logs/live-supervisor/test");
     expect(plan.botConfigPath).toBeUndefined();
     expect(plan.testerConfigPath).toBeUndefined();
+  });
+
+  it("accepts dynamic validation session artifact paths", () => {
+    const args = parseArgs(["--dry-run", "--out-dir", "log/validation/dynamic-test/chunks/chunk-0001/run-0001"]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: selectiveIgnoredChecker(new Set(["log/validation/dynamic-test/chunks/chunk-0001/run-0001"])) });
+
+    expect(plan.relativeOutDir).toBe("log/validation/dynamic-test/chunks/chunk-0001/run-0001");
+    expect(plan.botConfigPath).toBeUndefined();
+    expect(plan.testerConfigPath).toBeUndefined();
+  });
+
+  it("rejects validation roots outside run artifact directories", () => {
+    const args = parseArgs(["--dry-run", "--out-dir", "log/validation/dynamic-test"]);
+
+    expect(() => resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) })).toThrow(
+      "Supervisor output directory must be under logs/live-supervisor/ or a validation session run directory",
+    );
+  });
+
+  it("rejects validation run artifact directory descendants", () => {
+    const args = parseArgs(["--dry-run", "--out-dir", "log/validation/dynamic-test/chunks/chunk-0001/run-0001/extra"]);
+
+    expect(() => resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) })).toThrow(
+      "Supervisor output directory must be under logs/live-supervisor/ or a validation session run directory",
+    );
+  });
+
+  it("accepts explicit validation session roots outside the repo", () => {
+    const args = parseArgs(["--dry-run", "--out-dir", "/var/tmp/ickb-log/validation/dynamic-test/chunks/chunk-0001/run-0001"]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(false) });
+
+    expect(plan.relativeOutDir).toBe("/var/tmp/ickb-log/validation/dynamic-test/chunks/chunk-0001/run-0001");
+    expect(plan.outDir).toBe("/var/tmp/ickb-log/validation/dynamic-test/chunks/chunk-0001/run-0001");
+  });
+
+  it("refuses symlinked explicit validation parents outside the repo", async () => {
+    const args = parseArgs(["--dry-run", "--out-dir", "/var/tmp/ickb-log/validation/dynamic-test/chunks/chunk-0001/run-0001"]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(false) });
+
+    await expect(supervise(args, plan, {
+      lstat: (path) => Promise.resolve({ isSymbolicLink: () => pathToString(path) === "/var/tmp/ickb-log/validation" } as never),
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+    })).rejects.toThrow("Refusing to write supervisor artifacts through symlinked path: /var/tmp/ickb-log/validation");
   });
 
   it("resolves default ignored live config paths", () => {
@@ -206,7 +252,8 @@ describe("supervisor CLI", () => {
       const actor = spawned.find((item) => item.args[0] === "apps/bot/dist/index.js");
       expect(preflight?.env).not.toHaveProperty("PRIVATE_KEY");
       expect(preflight?.env).not.toHaveProperty("COWORKER_BUILD");
-      expect(actor?.env).toMatchObject({ BOT_CONFIG_FILE: "/repo/config/bot-testnet.json", INIT_CWD: "/repo" });
+      expect(preflight?.env).toMatchObject({ INIT_CWD: "/repo", NODE_OPTIONS: "--disable-warning=DEP0040" });
+      expect(actor?.env).toMatchObject({ BOT_CONFIG_FILE: "/repo/config/bot-testnet.json", INIT_CWD: "/repo", NODE_OPTIONS: "--disable-warning=DEP0040" });
       expect(actor?.env).not.toHaveProperty("PRIVATE_KEY");
       expect(actor?.env).not.toHaveProperty("COWORKER_BUILD");
     } finally {
@@ -372,7 +419,7 @@ describe("supervisor CLI", () => {
     expect(bot?.env).not.toHaveProperty("TESTER_FEE_BASE");
   });
 
-  it("runs the same tester twice for fresh-skip multi-order coverage", async () => {
+  it("runs the same tester twice for fresh-skip auto coverage", async () => {
     const spawned: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
     const writes = new Map<string, string>();
     let testerRuns = 0;
@@ -397,13 +444,9 @@ describe("supervisor CLI", () => {
           ? {
               startTime: "now",
               actions: {
-                requestedTesterScenario: "multi-order-limit-orders",
-                testerScenario: "mixed-direction-limit-orders",
-                newOrders: [
-                  { giveCkb: "10", takeIckb: "9", fee: "0.1" },
-                  { giveIckb: "20", takeCkb: "18", fee: "0.2" },
-                ],
-                orderCount: 2,
+                requestedTesterScenario: "auto",
+                testerScenario: "bounded-ickb-to-ckb-limit-order",
+                newOrder: { giveIckb: "20", takeCkb: "18", fee: "0.2" },
                 cancelledOrders: 0,
               },
               txHash: txHash("77"),
@@ -424,7 +467,7 @@ describe("supervisor CLI", () => {
     const testerSpawns = spawned.filter((item) => item.args[0] === "apps/tester/dist/index.js");
     expect(exitCode).toBe(0);
     expect(testerSpawns).toHaveLength(2);
-    expect(testerSpawns[0]?.env).toMatchObject({ TESTER_SCENARIO: "multi-order-limit-orders" });
+    expect(testerSpawns[0]?.env).toMatchObject({ TESTER_SCENARIO: "auto" });
     expect(testerSpawns[1]?.env).toMatchObject({ TESTER_SCENARIO: "auto" });
     expect(writes.has("/repo/logs/live-supervisor/two-pass-test/cycle-0001-tester-pass-1.stdout.ndjson")).toBe(true);
     expect(writes.has("/repo/logs/live-supervisor/two-pass-test/cycle-0001-tester-pass-2.stdout.ndjson")).toBe(true);
@@ -433,6 +476,211 @@ describe("supervisor CLI", () => {
       tester_order_created: 1,
       tester_fresh_order_skip: 1,
     });
+  });
+
+  it("uses tester auto for low-CKB first-pass fresh-skip fundability", async () => {
+    const spawned: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
+    let testerRuns = 0;
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/two-pass-low-ckb-test",
+      "--scenario", "tester-fresh-skip-two-pass",
+      "--target-outcome", "tester_order_created",
+      "--target-outcome", "tester_fresh_order_skip",
+      "--max-cycles", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) });
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      spawnCommand: ((_command: string, commandArgs: string[], options: { env?: NodeJS.ProcessEnv }) => {
+        spawned.push({ args: commandArgs, env: options.env });
+        if (isPreflightCommand(commandArgs)) {
+          return commandArgs.includes("tester-pass-1-1")
+            ? fakePreflightChild({ ckbAvailable: "2853.99897309", ickbAvailable: "250838.31219989" })
+            : fakeSuccessfulPreflightChild();
+        }
+        testerRuns += 1;
+        return fakeChild(JSON.stringify(testerRuns === 1
+          ? {
+              startTime: "now",
+              actions: {
+                requestedTesterScenario: "auto",
+                testerScenario: "bounded-ickb-to-ckb-limit-order",
+                newOrder: { giveIckb: "20", takeCkb: "18", fee: "0.2" },
+                cancelledOrders: 0,
+              },
+              txHash: txHash("78"),
+              ElapsedSeconds: 1,
+            }
+          : { skip: { reason: "fresh-matchable-order", txHash: txHash("78") } }));
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      appendFile: () => Promise.resolve(),
+      writeFile: () => Promise.resolve(),
+    });
+
+    const testerSpawns = spawned.filter((item) => item.args[0] === "apps/tester/dist/index.js");
+    expect(exitCode).toBe(0);
+    expect(testerSpawns).toHaveLength(2);
+    expect(testerSpawns[0]?.env).toMatchObject({ TESTER_SCENARIO: "auto" });
+    expect(testerSpawns[1]?.env).toMatchObject({ TESTER_SCENARIO: "auto" });
+  });
+
+  it("treats tester first-pass fresh-skip reserve misses as classified no-progress", async () => {
+    const spawned: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
+    const writes = new Map<string, string>();
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/two-pass-bounded-reserve-test",
+      "--scenario", "tester-fresh-skip-two-pass",
+      "--max-cycles", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) });
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      spawnCommand: ((_command: string, commandArgs: string[], options: { env?: NodeJS.ProcessEnv }) => {
+        spawned.push({ args: commandArgs, env: options.env });
+        return isPreflightCommand(commandArgs)
+          ? fakePreflightChild({ ckbAvailable: "2100", ickbAvailable: "250838.31219989" })
+          : fakeChild(JSON.stringify({ skip: { reason: "post-tx-ckb-reserve" } }));
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      appendFile: () => Promise.resolve(),
+      writeFile: (path, text) => {
+        writes.set(pathToString(path), textToString(text));
+        return Promise.resolve();
+      },
+    });
+
+    const testerSpawns = spawned.filter((item) => item.args[0] === "apps/tester/dist/index.js");
+    expect(exitCode).toBe(0);
+    expect(testerSpawns[0]?.env).toMatchObject({ TESTER_SCENARIO: "auto" });
+    expect([...writes.keys()].some((path) => path.endsWith("incident.json"))).toBe(false);
+    const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/two-pass-bounded-reserve-test/summary.json");
+    expect(summary).toMatchObject({ stopped: "max_cycles", skipReasons: ["post-tx-ckb-reserve", "post-tx-ckb-reserve"] });
+    expect(recordAt(summary["aggregateCounts"], "summary aggregate counts")).toEqual({ tester_reserve_skip: 2 });
+  });
+
+  it("uses auto first-pass fresh-skip stimulus when plain CKB is very low", async () => {
+    const spawned: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/two-pass-low-reserve-test",
+      "--scenario", "tester-fresh-skip-two-pass",
+      "--target-outcome", "tester_order_created",
+      "--target-outcome", "tester_fresh_order_skip",
+      "--max-cycles", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) });
+
+    await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      spawnCommand: ((_command: string, commandArgs: string[], options: { env?: NodeJS.ProcessEnv }) => {
+        spawned.push({ args: commandArgs, env: options.env });
+        return isPreflightCommand(commandArgs)
+          ? fakePreflightChild({ ckbAvailable: "1999.99999999", ickbAvailable: "250838.31219989" })
+          : fakeChild(JSON.stringify({ skip: { reason: "post-tx-ckb-reserve" } }));
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      appendFile: () => Promise.resolve(),
+      writeFile: () => Promise.resolve(),
+    });
+
+    const tester = spawned.find((item) => item.args[0] === "apps/tester/dist/index.js");
+    expect(tester?.env).toMatchObject({ TESTER_SCENARIO: "auto" });
+  });
+
+  it("uses auto first-pass fresh-skip stimulus when plain CKB is high", async () => {
+    const spawned: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
+    let testerRuns = 0;
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/two-pass-high-ckb-test",
+      "--scenario", "tester-fresh-skip-two-pass",
+      "--target-outcome", "tester_order_created",
+      "--target-outcome", "tester_fresh_order_skip",
+      "--max-cycles", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) });
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      spawnCommand: ((_command: string, commandArgs: string[], options: { env?: NodeJS.ProcessEnv }) => {
+        spawned.push({ args: commandArgs, env: options.env });
+        if (isPreflightCommand(commandArgs)) {
+          return commandArgs.includes("tester-pass-1-1")
+            ? fakePreflightChild({ ckbAvailable: "3000", ickbAvailable: "250838.31219989" })
+            : fakeSuccessfulPreflightChild();
+        }
+        testerRuns += 1;
+        return fakeChild(JSON.stringify(testerRuns === 1
+          ? {
+              startTime: "now",
+              actions: {
+                requestedTesterScenario: "auto",
+                testerScenario: "bounded-ickb-to-ckb-limit-order",
+                newOrder: { giveIckb: "20", takeCkb: "18", fee: "0.2" },
+                cancelledOrders: 0,
+              },
+              txHash: txHash("80"),
+              ElapsedSeconds: 1,
+            }
+          : { skip: { reason: "fresh-matchable-order", txHash: txHash("80") } }));
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      appendFile: () => Promise.resolve(),
+      writeFile: () => Promise.resolve(),
+    });
+
+    const testerSpawns = spawned.filter((item) => item.args[0] === "apps/tester/dist/index.js");
+    expect(exitCode).toBe(0);
+    expect(testerSpawns[0]?.env).toMatchObject({ TESTER_SCENARIO: "auto" });
+    expect(testerSpawns[1]?.env).toMatchObject({ TESTER_SCENARIO: "auto" });
+  });
+
+  it("preserves explicit tester scenario during fresh-skip pass selection", async () => {
+    const spawned: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/two-pass-explicit-test",
+      "--scenario", "tester-fresh-skip-two-pass",
+      "--tester-scenario", "multi-order-limit-orders",
+      "--max-cycles", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) });
+
+    await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      spawnCommand: ((_command: string, commandArgs: string[], options: { env?: NodeJS.ProcessEnv }) => {
+        spawned.push({ args: commandArgs, env: options.env });
+        return isPreflightCommand(commandArgs)
+          ? fakePreflightChild({ ckbAvailable: "2853.99897309", ickbAvailable: "250838.31219989" })
+          : fakeChild(JSON.stringify({
+              startTime: "now",
+              actions: {
+                requestedTesterScenario: "auto",
+                testerScenario: "bounded-ickb-to-ckb-limit-order",
+                newOrder: { giveIckb: "20", takeCkb: "18", fee: "0.2" },
+                cancelledOrders: 0,
+              },
+              txHash: txHash("79"),
+              ElapsedSeconds: 1,
+            }));
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      appendFile: () => Promise.resolve(),
+      writeFile: () => Promise.resolve(),
+    });
+
+    const tester = spawned.find((item) => item.args[0] === "apps/tester/dist/index.js");
+    expect(tester?.env).toMatchObject({ TESTER_SCENARIO: "multi-order-limit-orders" });
   });
 
   it("refuses live config paths through symlinked parents", async () => {
@@ -585,6 +833,28 @@ describe("classification", () => {
     });
   });
 
+  it("rejects committed tester evidence without action evidence", () => {
+    expect(classifyActorResult("tester", commandResult("tester", JSON.stringify({
+      startTime: "now",
+      txHash: txHash("25"),
+      ElapsedSeconds: 1,
+    })))).toMatchObject({
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: "tester committed transaction evidence did not include action evidence",
+    });
+    expect(classifyActorResult("tester", commandResult("tester", JSON.stringify({
+      startTime: "now",
+      actions: { cancelledOrders: 0 },
+      txHash: txHash("26"),
+      ElapsedSeconds: 1,
+    })))).toMatchObject({
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: "tester committed transaction evidence did not include action evidence",
+    });
+  });
+
   it("classifies tester SDK order conversions as conversion coverage", () => {
     const result = commandResult("tester", JSON.stringify({
       startTime: "now",
@@ -606,7 +876,8 @@ describe("classification", () => {
       actions: {
         testerScenario: "ickb-to-ckb-limit-order",
         newOrder: { giveIckb: "10", takeCkb: "9", fee: "0.1" },
-        cancelledOrders: 0,
+        collectedOrders: 2,
+        cancelledOrders: 1,
       },
       txHash: txHash("15"),
       ElapsedSeconds: 1,
@@ -615,6 +886,38 @@ describe("classification", () => {
     expect(classifyActorResult("tester", result, { scenario: "ickb-to-ckb-limit-order" })).toMatchObject({
       outcome: "tester_order_created",
       terminal: false,
+      testerOrder: {
+        testerScenario: "ickb-to-ckb-limit-order",
+        orderCount: 1,
+        collectedOrders: 2,
+        cancelledOrders: 1,
+        orders: [{ direction: "ickb-to-ckb", giveIckb: "10", takeCkb: "9", fee: "0.1", dust: false }],
+      },
+    });
+  });
+
+  it("captures dust tester order evidence", () => {
+    const result = commandResult("tester", JSON.stringify({
+      startTime: "now",
+      actions: {
+        requestedTesterScenario: "auto",
+        testerScenario: "dust-ckb-conversion",
+        newOrder: { giveCkb: "0.00000001", takeIckb: "0.00000001", fee: "0", feeNumerator: "1", feeBase: "100000" },
+        cancelledOrders: 1,
+      },
+      txHash: txHash("17"),
+      ElapsedSeconds: 1,
+    }));
+
+    expect(classifyActorResult("tester", result)).toMatchObject({
+      outcome: "tester_order_created",
+      testerOrder: {
+        requestedTesterScenario: "auto",
+        testerScenario: "dust-ckb-conversion",
+        orderCount: 1,
+        cancelledOrders: 1,
+        orders: [{ direction: "ckb-to-ickb", giveCkb: "0.00000001", takeIckb: "0.00000001", fee: "0", feeNumerator: "1", feeBase: "100000", dust: true }],
+      },
     });
   });
 
@@ -918,6 +1221,24 @@ describe("classification", () => {
     });
   });
 
+  it("accepts bounded iCKB-to-CKB tester scenario evidence", () => {
+    const result = commandResult("tester", JSON.stringify({
+      startTime: "now",
+      actions: {
+        testerScenario: "bounded-ickb-to-ckb-limit-order",
+        newOrder: { giveIckb: "10", takeCkb: "9", fee: "0.1" },
+        cancelledOrders: 0,
+      },
+      txHash: txHash("18"),
+      ElapsedSeconds: 1,
+    }));
+
+    expect(classifyActorResult("tester", result, { scenario: "bounded-ickb-to-ckb-limit-order" })).toMatchObject({
+      outcome: "tester_order_created",
+      terminal: false,
+    });
+  });
+
   it("requires conversion evidence for explicit SDK conversion scenarios", () => {
     const result = commandResult("tester", JSON.stringify({
       startTime: "now",
@@ -941,6 +1262,13 @@ describe("classification", () => {
     expect(classifyActorResult("tester", commandResult("tester", JSON.stringify({
       skip: { reason: "fresh-matchable-order", txHash: txHash("22") },
     }))).outcome).toBe("tester_fresh_order_skip");
+    expect(classifyActorResult("tester", commandResult("tester", JSON.stringify({
+      skip: { reason: "matchable-order-transaction-missing", txHash: txHash("23") },
+    })))).toMatchObject({
+      outcome: "tester_fresh_order_skip",
+      terminal: false,
+      skipReason: "matchable-order-transaction-missing",
+    });
     expect(classifyActorResult("tester", commandResult("tester", JSON.stringify({
       skip: { reason: "sampled-amount-too-small" },
     }))).outcome).toBe("tester_sampled_too_small_skip");
@@ -993,6 +1321,66 @@ describe("classification", () => {
     });
   });
 
+  it("classifies matched withdrawal requests as withdrawal coverage", () => {
+    const stdout = [
+      botEvent("bot.transaction.built", {
+        actions: { collectedOrders: 0, completedDeposits: 0, matchedOrders: 1, deposits: 0, withdrawalRequests: 1, withdrawals: 0 },
+      }),
+      botEvent("bot.transaction.committed", { txHash: txHash("39"), status: "committed" }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "bot_withdrawal_request_committed",
+      actions: { matchedOrders: 1, deposits: 0, withdrawalRequests: 1 },
+      txHashes: [txHash("39")],
+    });
+  });
+
+  it("classifies matched receipt completions as receipt coverage", () => {
+    const stdout = [
+      botEvent("bot.transaction.built", {
+        actions: { collectedOrders: 0, completedDeposits: 1, matchedOrders: 1, deposits: 0, withdrawalRequests: 0, withdrawals: 0 },
+      }),
+      botEvent("bot.transaction.committed", { txHash: txHash("40"), status: "committed" }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "bot_receipt_completion_committed",
+      actions: { completedDeposits: 1, matchedOrders: 1, deposits: 0 },
+      txHashes: [txHash("40")],
+    });
+  });
+
+  it("classifies matched withdrawal completions as withdrawal completion coverage", () => {
+    const stdout = [
+      botEvent("bot.transaction.built", {
+        actions: { collectedOrders: 0, completedDeposits: 0, matchedOrders: 1, deposits: 0, withdrawalRequests: 0, withdrawals: 1 },
+      }),
+      botEvent("bot.transaction.committed", { txHash: txHash("41"), status: "committed" }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "bot_withdrawal_completion_committed",
+      actions: { matchedOrders: 1, deposits: 0, withdrawals: 1 },
+      txHashes: [txHash("41")],
+    });
+  });
+
+  it("classifies deposit-only commits as deposit coverage", () => {
+    const stdout = [
+      botEvent("bot.transaction.built", {
+        actions: { collectedOrders: 0, completedDeposits: 0, matchedOrders: 0, deposits: 1, withdrawalRequests: 0, withdrawals: 0 },
+      }),
+      botEvent("bot.transaction.committed", { txHash: txHash("42"), status: "committed" }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "bot_deposit_only_committed",
+      actions: { matchedOrders: 0, deposits: 1 },
+      txHashes: [txHash("42")],
+    });
+  });
+
   it("keeps match diagnostics tied to the matching state-read iteration", () => {
     const stdout = [
       botEvent("bot.state.read", {
@@ -1040,6 +1428,165 @@ describe("classification", () => {
       readyPoolDepositCount: 0,
       nearReadyPoolDepositCount: 0,
       futurePoolDepositCount: 0,
+    });
+    expect(classification).toMatchObject({
+      outcome: "bot_retryable_error",
+      terminal: false,
+      reason: "bot reported retryable iteration failure",
+    });
+  });
+
+  it("classifies bot committed actions from the matching iteration", () => {
+    const stdout = [
+      botEvent("bot.iteration.failed", {
+        iterationId: 0,
+        retryable: false,
+        terminal: true,
+        error: { name: "Error", message: "L1 state scan crossed chain tip; retry with a fresh state" },
+      }),
+      botEvent("bot.transaction.built", {
+        iterationId: 1,
+        actions: { collectedOrders: 0, completedDeposits: 0, matchedOrders: 1, deposits: 0, withdrawalRequests: 0, withdrawals: 0 },
+      }),
+      botEvent("bot.transaction.built", {
+        iterationId: 2,
+        actions: { collectedOrders: 0, completedDeposits: 0, matchedOrders: 0, deposits: 1, withdrawalRequests: 0, withdrawals: 0 },
+      }),
+      botEvent("bot.transaction.committed", { iterationId: 1, txHash: txHash("37"), status: "committed" }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "bot_match_committed",
+      actions: { matchedOrders: 1, deposits: 0 },
+    });
+  });
+
+  it("classifies later bot commits over older transaction failures", () => {
+    const stdout = [
+      botEvent("bot.transaction.built", {
+        iterationId: 1,
+        actions: { collectedOrders: 0, completedDeposits: 0, matchedOrders: 1, deposits: 0, withdrawalRequests: 0, withdrawals: 0 },
+      }),
+      botEvent("bot.transaction.failed", {
+        iterationId: 1,
+        outcome: "post_broadcast_unresolved",
+        txHash: txHash("43"),
+      }),
+      botEvent("bot.transaction.committed", { iterationId: 1, txHash: txHash("44"), status: "committed" }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "bot_match_committed",
+      terminal: false,
+      actions: { matchedOrders: 1, deposits: 0 },
+    });
+  });
+
+  it("classifies later bot transaction failures over older commits", () => {
+    const stdout = [
+      botEvent("bot.transaction.built", {
+        iterationId: 1,
+        actions: { collectedOrders: 0, completedDeposits: 0, matchedOrders: 1, deposits: 0, withdrawalRequests: 0, withdrawals: 0 },
+      }),
+      botEvent("bot.transaction.committed", { iterationId: 1, txHash: txHash("45"), status: "committed" }),
+      botEvent("bot.transaction.failed", {
+        iterationId: 1,
+        outcome: "terminal_rejection",
+        txHash: txHash("46"),
+      }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "terminal_chain_rejection",
+      terminal: true,
+    });
+  });
+
+  it("rejects bot post-broadcast failures without a valid tx hash", () => {
+    const stdout = JSON.stringify(botEvent("bot.transaction.failed", {
+      outcome: "post_broadcast_unresolved",
+      txHash: "not-a-tx-hash",
+    }));
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: "bot post-broadcast transaction failure evidence did not include a valid tx hash",
+    });
+  });
+
+  it("keeps pre-broadcast bot failures classified without tx hash evidence", () => {
+    const stdout = JSON.stringify(botEvent("bot.transaction.failed", {
+      outcome: "validation_failed",
+      phase: "pre_broadcast",
+    }));
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "unknown",
+      terminal: true,
+      reason: "bot pre-broadcast transaction failure",
+    });
+  });
+
+  it("classifies bot skips after earlier terminal iteration failures", () => {
+    const stdout = [
+      botEvent("bot.iteration.failed", {
+        iterationId: 1,
+        retryable: false,
+        terminal: true,
+        error: { name: "Error", message: "L1 state scan crossed chain tip; retry with a fresh state" },
+      }),
+      botEvent("bot.decision.skipped", {
+        iterationId: 2,
+        reason: "no_actions",
+        actions: emptyActions(),
+      }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "bot_no_action_skip",
+      terminal: false,
+      skipReason: "no_actions",
+    });
+  });
+
+  it("classifies bot skips after earlier retryable pre-broadcast failures", () => {
+    const stdout = [
+      botEvent("bot.transaction.failed", {
+        iterationId: 1,
+        phase: "pre_broadcast",
+        outcome: "pre_broadcast_failed",
+        retryable: true,
+        terminal: false,
+        error: { name: "TypeError", message: "fetch failed" },
+      }),
+      botEvent("bot.decision.skipped", {
+        iterationId: 2,
+        reason: "no_actions",
+        actions: emptyActions(),
+      }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "bot_no_action_skip",
+      terminal: false,
+      skipReason: "no_actions",
+    });
+  });
+
+  it("rejects committed bot evidence without matching built action evidence", () => {
+    const stdout = [
+      botEvent("bot.transaction.built", {
+        iterationId: 1,
+        actions: { collectedOrders: 0, completedDeposits: 0, matchedOrders: 1, deposits: 0, withdrawalRequests: 0, withdrawals: 0 },
+      }),
+      botEvent("bot.transaction.committed", { iterationId: 2, txHash: txHash("38"), status: "committed" }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: "bot committed transaction evidence did not include matching built action evidence",
     });
   });
 
@@ -1108,6 +1655,42 @@ describe("classification", () => {
     });
   });
 
+  it("treats nonzero bot exits as terminal even with retryable iteration evidence", () => {
+    const result = {
+      ...commandResult("bot", JSON.stringify(botEvent("bot.iteration.failed", {
+        retryable: true,
+        terminal: false,
+        error: { name: "TypeError", message: "fetch failed" },
+      }))),
+      status: 1,
+    };
+
+    expect(classifyActorResult("bot", result)).toMatchObject({
+      outcome: "nonzero_exit",
+      terminal: true,
+    });
+  });
+
+  it("keeps terminal bot retry-budget exhaustion classified by bot evidence despite exit code 2", () => {
+    const result = {
+      ...commandResult("bot", JSON.stringify(botEvent("bot.iteration.failed", {
+        retryable: true,
+        terminal: true,
+        retryableAttempts: 3,
+        maxRetryableAttempts: 3,
+        retryBudgetExhausted: true,
+        error: { name: "TypeError", message: "fetch failed" },
+      }))),
+      status: 2,
+    };
+
+    expect(classifyActorResult("bot", result)).toMatchObject({
+      outcome: "bot_retryable_error",
+      terminal: true,
+      reason: "bot reported terminal retryable iteration failure",
+    });
+  });
+
   it("reports spawn errors before generic actor exit classification", () => {
     expect(classifyActorResult("preflight", { ...commandResult("preflight", ""), spawnError: "ENOENT", status: null })).toMatchObject({
       outcome: "nonzero_exit",
@@ -1135,6 +1718,7 @@ describe("classification", () => {
           message: "Transaction confirmation timed out",
           txHash: txHash("aa"),
           status: "sent",
+          isTimeout: true,
         },
       })),
       status: 2,
@@ -1143,6 +1727,90 @@ describe("classification", () => {
     expect(classifyActorResult("tester", result)).toMatchObject({
       outcome: "confirmation_timeout",
       terminal: true,
+    });
+  });
+
+  it("classifies serialized tester post-broadcast unresolved failures", () => {
+    const result = {
+      ...commandResult("tester", JSON.stringify({
+        txHash: txHash("ab"),
+        error: {
+          name: "TransactionConfirmationError",
+          message: "Transaction confirmation timed out",
+          txHash: txHash("ab"),
+          status: "sent",
+          isTimeout: true,
+          cause: { name: "TypeError", message: "fetch failed" },
+        },
+      })),
+      status: 2,
+    };
+
+    expect(classifyActorResult("tester", result)).toMatchObject({
+      outcome: "post_broadcast_unresolved",
+      terminal: true,
+      reason: "tester tx remained unresolved after broadcast",
+    });
+  });
+
+  it("classifies serialized tester terminal chain rejections", () => {
+    const result = {
+      ...commandResult("tester", JSON.stringify({
+        txHash: txHash("ac"),
+        error: {
+          name: "TransactionConfirmationError",
+          message: "Transaction reached rejected status",
+          txHash: txHash("ac"),
+          status: "rejected",
+          isTimeout: false,
+        },
+      })),
+      status: 1,
+    };
+
+    expect(classifyActorResult("tester", result)).toMatchObject({
+      outcome: "terminal_chain_rejection",
+      terminal: true,
+      reason: "tester tx reached terminal chain rejection",
+    });
+  });
+
+  it("rejects tester transaction failures without valid tx hash evidence", () => {
+    const result = {
+      ...commandResult("tester", JSON.stringify({
+        error: {
+          name: "TransactionConfirmationError",
+          message: "Transaction confirmation timed out",
+          isTimeout: true,
+        },
+      })),
+      status: 2,
+    };
+
+    expect(classifyActorResult("tester", result)).toMatchObject({
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: "tester transaction failure evidence did not include a valid tx hash",
+    });
+  });
+
+  it("extracts nested tester transaction failure tx hash evidence", () => {
+    const result = {
+      ...commandResult("tester", JSON.stringify({
+        error: {
+          name: "TransactionConfirmationError",
+          message: "Transaction confirmation timed out",
+          txHash: txHash("ad"),
+          isTimeout: true,
+        },
+      })),
+      status: 2,
+    };
+
+    expect(classifyActorResult("tester", result)).toMatchObject({
+      outcome: "confirmation_timeout",
+      terminal: true,
+      txHashes: [txHash("ad")],
     });
   });
 
@@ -1163,69 +1831,123 @@ describe("classification", () => {
     });
   });
 
-  it("safety classifications override ordinary exits", () => {
+  it("safety classifications preserve ordinary command precedence", () => {
     expect(classifyActorResult("bot", commandResult("bot", "{not-json}"))).toMatchObject({
       outcome: "malformed_evidence",
-      terminal: true,
-    });
-    expect(classifyActorResult("bot", commandResult("bot", JSON.stringify({ privateKey: "0xsecret" })))).toMatchObject({
-      outcome: "secret_leak_sentinel",
       terminal: true,
     });
     expect(classifyActorResult("bot", { ...commandResult("bot", ""), timedOut: true })).toMatchObject({
       outcome: "command_timeout",
       terminal: true,
     });
+    expect(classifyActorResult("bot", commandResult("bot", [
+      JSON.stringify(botEvent("bot.decision.skipped", { reason: "no_actions", actions: emptyActions() })),
+      JSON.stringify({ witnesses: ["0xsignature"], inputs: [] }),
+    ].join("\n")))).toMatchObject({
+      outcome: "bot_no_action_skip",
+      terminal: false,
+    });
   });
 
-  it("classifies terminal preflight safety failures before launch", () => {
+  it("classifies terminal preflight command failures before launch", () => {
     expect(classifyActorResult("preflight", { ...commandResult("preflight", ""), timedOut: true })).toMatchObject({
       outcome: "command_timeout",
       terminal: true,
     });
+  });
+
+  it("requires preflight configs to bound actors to one iteration", () => {
     expect(classifyActorResult("preflight", commandResult("preflight", JSON.stringify({
-      privateKey: "0xsecret",
+      chain: "testnet",
+      bounded: false,
     })))).toMatchObject({
-      outcome: "secret_leak_sentinel",
+      outcome: "malformed_evidence",
       terminal: true,
+      reason: "preflight config is not bounded to one iteration",
+    });
+    expect(classifyActorResult("preflight", commandResult("preflight", JSON.stringify({
+      chain: "testnet",
+      bounded: true,
+      maxIterations: 2,
+    })))).toMatchObject({
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: "preflight config is not bounded to one iteration",
     });
   });
 
-  it("sanitizes transaction-shaped preflight errors before classification reaches artifacts", () => {
+  it("fails closed when captured command output is truncated", () => {
+    expect(classifyActorResult("bot", {
+      ...commandResult("bot", JSON.stringify(botEvent("bot.decision.skipped", {
+        reason: "no_actions",
+        actions: emptyActions(),
+      }))),
+      stdoutTruncated: true,
+    })).toMatchObject({
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: "stdout evidence exceeded supervisor capture limit",
+      evidence: { stdoutTruncated: true },
+    });
+    expect(classifyActorResult("preflight", {
+      ...commandResult("preflight", JSON.stringify({ chain: "testnet", bounded: true, maxIterations: 1 })),
+      stderrTruncated: true,
+    })).toMatchObject({
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: "stderr evidence exceeded supervisor capture limit",
+      evidence: { stderrTruncated: true },
+    });
+  });
+
+  it("preserves transaction-shaped preflight stderr for artifact capture", () => {
     const classification = classifyActorResult("preflight", {
       ...commandResult("preflight", "{}"),
       status: 1,
       stderr: JSON.stringify({ witnesses: ["0xsignature"], inputs: [] }),
     });
 
-    expect(classification.reason).toBe("<redacted: transaction-shaped output withheld by supervisor>\n");
+    expect(classification).toMatchObject({
+      outcome: "nonzero_exit",
+      terminal: true,
+      reason: JSON.stringify({ witnesses: ["0xsignature"], inputs: [] }),
+    });
   });
 
-  it("withholds secret-shaped raw artifacts", () => {
-    expect(safeArtifactText(JSON.stringify({ privateKey: "0xsecret" }))).toBe(
-      "<redacted: secret-shaped output withheld by supervisor>\n",
-    );
-    expect(safeArtifactText(`PRIVATE_KEY=0x${"11".repeat(32)}`)).toBe(
-      "<redacted: secret-shaped output withheld by supervisor>\n",
-    );
-    expect(safeArtifactText("SEED_PHRASE=alpha beta gamma")).toBe(
-      "<redacted: secret-shaped output withheld by supervisor>\n",
-    );
-    expect(safeArtifactText("RPC_URL=https://user:pass@testnet.example/path?token=secret")).toBe(
-      "<redacted: secret-shaped output withheld by supervisor>\n",
-    );
-    expect(safeArtifactText(JSON.stringify({ witnesses: ["0xsignature"], inputs: [] }))).toBe(
-      "<redacted: transaction-shaped output withheld by supervisor>\n",
-    );
-    expect(safeArtifactText(JSON.stringify({
-      transactionShape: { inputs: 1, outputs: 2, cellDeps: 3, headerDeps: 4, witnesses: 5 },
-    }))).toBe(
-      JSON.stringify({ transactionShape: { inputs: 1, outputs: 2, cellDeps: 3, headerDeps: 4, witnesses: 5 } }),
-    );
-    expect(safeArtifactText(JSON.stringify({ system: { tip: { hash: txHash("aa") } } }))).toBe(
-      JSON.stringify({ system: { tip: { hash: txHash("aa") } } }),
-    );
-    expect(safeArtifactText(JSON.stringify({ app: "bot" }))).toBe(JSON.stringify({ app: "bot" }));
+  it("preserves snake_case CKB transaction fields for artifact capture", () => {
+    const classification = classifyActorResult("preflight", {
+      ...commandResult("preflight", "{}"),
+      status: 1,
+      stderr: JSON.stringify({ cell_deps: [], header_deps: [], outputs_data: ["0x"] }),
+    });
+
+    expect(classification).toMatchObject({
+      outcome: "nonzero_exit",
+      terminal: true,
+      reason: JSON.stringify({ cell_deps: [], header_deps: [], outputs_data: ["0x"] }),
+    });
+  });
+
+  it("classifies retryable preflight transport failures separately", () => {
+    expect(classifyActorResult("preflight", {
+      ...commandResult("preflight", ""),
+      status: 1,
+      stderr: "Live preflight retryable failure: fetch failed\n",
+    })).toMatchObject({
+      outcome: "preflight_retryable_error",
+      terminal: true,
+    });
+  });
+
+  it("classifies preserved wrong-chain preflight evidence", () => {
+    expect(classifyActorResult("preflight", {
+      ...commandResult("preflight", ""),
+      status: 1,
+      stderr: "Live preflight failed: Invalid testnet RPC chain identity: genesis hash expected 0x1 observed 0x2\n",
+    })).toMatchObject({
+      outcome: "wrong_chain",
+      terminal: true,
+    });
   });
 
   it("caps captured command output", () => {
@@ -1294,6 +2016,271 @@ describe("classification", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("bounds in-flight actor commands by the remaining wall-clock budget", async () => {
+    vi.useFakeTimers();
+    try {
+      const writes = new Map<string, string>();
+      const kills: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+      const args = parseArgs([
+        "--out-dir", "logs/live-supervisor/wall-clock-timeout-test",
+        "--scenario", "bot-only",
+        "--target-outcome", "bot_match_committed",
+        "--max-cycles", "1",
+        "--max-wall-clock-seconds", "1",
+        "--command-timeout-seconds", "900",
+      ]);
+      const plan = resolvePlan(args, "/repo", { spawnSyncCommand: selectiveIgnoredChecker(new Set([
+        "logs/live-supervisor/wall-clock-timeout-test",
+        "config/bot-testnet.json",
+        "config/tester-testnet.json",
+      ])) });
+      const child = fakeHangingChild();
+
+      const run = supervise(args, plan, {
+        skipBuiltRuntimeCheck: true,
+        commandKillGraceMs: 10,
+        killProcess: (pid, signal) => {
+          kills.push({ pid, signal });
+          if (signal === "SIGKILL") {
+            queueMicrotask(() => child.emit("close", null, "SIGKILL"));
+          }
+        },
+        spawnCommand: ((_command: string, commandArgs: string[]) => isPreflightCommand(commandArgs) ? fakeSuccessfulPreflightChild() : child) as never,
+        spawnSyncCommand: ignoredChecker(true) as never,
+        lstat: missingStat,
+        stat: missingStat,
+        mkdir: () => Promise.resolve(undefined),
+        realpath: (path) => Promise.resolve(pathToString(path)),
+        appendFile: (path, text) => {
+          const key = pathToString(path);
+          writes.set(key, `${writes.get(key) ?? ""}${textToString(text)}`);
+          return Promise.resolve();
+        },
+        writeFile: (path, text) => {
+          writes.set(pathToString(path), textToString(text));
+          return Promise.resolve();
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(1010);
+
+      await expect(run).resolves.toBe(2);
+      expect(kills).toEqual([
+        { pid: -1234, signal: "SIGTERM" },
+        { pid: -1234, signal: "SIGKILL" },
+      ]);
+      const incident = jsonArtifact(writes, "/repo/logs/live-supervisor/wall-clock-timeout-test/cycle-0001-incident.json");
+      expect(recordAt(incident["classification"], "incident classification")).toMatchObject({
+        outcome: "command_timeout",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not spawn actor commands when wall-clock expires at the command boundary", async () => {
+    const writes = new Map<string, string>();
+    const spawned: string[][] = [];
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/wall-clock-boundary-test",
+      "--scenario", "bot-only",
+      "--target-outcome", "bot_match_committed",
+      "--max-cycles", "1",
+      "--max-wall-clock-seconds", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: selectiveIgnoredChecker(new Set([
+      "logs/live-supervisor/wall-clock-boundary-test",
+      "config/bot-testnet.json",
+      "config/tester-testnet.json",
+    ])) });
+    const clock = [0, 999, 1000, 1000];
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      now: () => clock.shift() ?? 1000,
+      spawnCommand: ((_command: string, commandArgs: string[]) => {
+        spawned.push(commandArgs);
+        return fakeChild("should not run");
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      lstat: missingStat,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      realpath: (path) => Promise.resolve(pathToString(path)),
+      appendFile: (path, text) => {
+        const key = pathToString(path);
+        writes.set(key, `${writes.get(key) ?? ""}${textToString(text)}`);
+        return Promise.resolve();
+      },
+      writeFile: (path, text) => {
+        writes.set(pathToString(path), textToString(text));
+        return Promise.resolve();
+      },
+    });
+
+    expect(exitCode).toBe(2);
+    expect(spawned).toEqual([]);
+    const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/wall-clock-boundary-test/summary.json");
+    expect(summary).toMatchObject({ stopped: "unmet_coverage_goal" });
+  });
+
+  it("retries retryable preflight transport failures once before actor execution", async () => {
+    const writes = new Map<string, string>();
+    const spawned: string[][] = [];
+    let preflightRuns = 0;
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/preflight-retry-test",
+      "--scenario", "bot-only",
+      "--max-cycles", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: selectiveIgnoredChecker(new Set([
+      "logs/live-supervisor/preflight-retry-test",
+      "config/bot-testnet.json",
+      "config/tester-testnet.json",
+    ])) });
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      spawnCommand: ((_command: string, commandArgs: string[]) => {
+        spawned.push(commandArgs);
+        if (isPreflightCommand(commandArgs)) {
+          preflightRuns += 1;
+          return preflightRuns === 1
+            ? fakeChild("", 1, "Live preflight retryable failure: fetch failed\n")
+            : fakeSuccessfulPreflightChild();
+        }
+        return fakeChild(JSON.stringify(botEvent("bot.decision.skipped", {
+          reason: "no_actions",
+          actions: emptyActions(),
+        })));
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      lstat: missingStat,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      realpath: (path) => Promise.resolve(pathToString(path)),
+      appendFile: (path, text) => {
+        const key = pathToString(path);
+        writes.set(key, `${writes.get(key) ?? ""}${textToString(text)}`);
+        return Promise.resolve();
+      },
+      writeFile: (path, text) => {
+        writes.set(pathToString(path), textToString(text));
+        return Promise.resolve();
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(spawned.filter((args) => isPreflightCommand(args))).toHaveLength(2);
+    expect(spawned.filter((args) => !isPreflightCommand(args))).toHaveLength(1);
+    expect(writes.has("/repo/logs/live-supervisor/preflight-retry-test/cycle-0001-bot-preflight-attempt-1.stdout.json")).toBe(true);
+    expect(writes.has("/repo/logs/live-supervisor/preflight-retry-test/cycle-0001-bot-preflight-attempt-1.stdout.ndjson")).toBe(false);
+    expect(writes.has("/repo/logs/live-supervisor/preflight-retry-test/cycle-0001-bot-preflight-attempt-2.stdout.json")).toBe(true);
+    expect(writes.has("/repo/logs/live-supervisor/preflight-retry-test/cycle-0001-bot-preflight-attempt-1.command.json")).toBe(true);
+    expect(writes.has("/repo/logs/live-supervisor/preflight-retry-test/cycle-0001-bot-preflight-attempt-2.command.json")).toBe(true);
+    const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/preflight-retry-test/summary.json");
+    expect(recordAt(summary["aggregateCounts"], "summary aggregate counts")).toMatchObject({ bot_no_action_skip: 1 });
+  });
+
+  it("writes retryable-looking preflight output as public producer artifacts", async () => {
+    const writes = new Map<string, string>();
+    const spawned: string[][] = [];
+    const preflightOutput = JSON.stringify({ diagnostic: "public preflight output" });
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/preflight-unsafe-retry-test",
+      "--scenario", "bot-only",
+      "--max-cycles", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: selectiveIgnoredChecker(new Set([
+      "logs/live-supervisor/preflight-unsafe-retry-test",
+      "config/bot-testnet.json",
+      "config/tester-testnet.json",
+    ])) });
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      spawnCommand: ((_command: string, commandArgs: string[]) => {
+        spawned.push(commandArgs);
+        return fakeChild(preflightOutput, 1, "Live preflight retryable failure: fetch failed\n");
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      lstat: missingStat,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      realpath: (path) => Promise.resolve(pathToString(path)),
+      appendFile: (path, text) => {
+        const key = pathToString(path);
+        writes.set(key, `${writes.get(key) ?? ""}${textToString(text)}`);
+        return Promise.resolve();
+      },
+      writeFile: (path, text) => {
+        writes.set(pathToString(path), textToString(text));
+        return Promise.resolve();
+      },
+    });
+
+    expect(exitCode).toBe(2);
+    expect(spawned.filter((args) => isPreflightCommand(args))).toHaveLength(2);
+    expect(spawned.filter((args) => !isPreflightCommand(args))).toHaveLength(0);
+    const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/preflight-unsafe-retry-test/summary.json");
+    expect(summary).toMatchObject({ stopped: "preflight_retryable_error" });
+    expect(recordAt(summary["aggregateCounts"], "summary aggregate counts")).toMatchObject({ preflight_retryable_error: 1 });
+    expect(writes.get("/repo/logs/live-supervisor/preflight-unsafe-retry-test/cycle-0001-bot-preflight-attempt-1.stdout.json")).toBe(
+      `${preflightOutput}\n`,
+    );
+    expect(writes.get("/repo/logs/live-supervisor/preflight-unsafe-retry-test/cycle-0001-bot-preflight-attempt-2.stdout.json")).toBe(
+      `${preflightOutput}\n`,
+    );
+  });
+
+  it("does not retry preflight after the wall-clock budget expires", async () => {
+    const writes = new Map<string, string>();
+    const spawned: string[][] = [];
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/preflight-retry-wall-clock-test",
+      "--scenario", "bot-only",
+      "--target-outcome", "bot_match_committed",
+      "--max-cycles", "1",
+      "--max-wall-clock-seconds", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: selectiveIgnoredChecker(new Set([
+      "logs/live-supervisor/preflight-retry-wall-clock-test",
+      "config/bot-testnet.json",
+      "config/tester-testnet.json",
+    ])) });
+    const clock = [0, 0, 0, 0, 2000];
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      now: () => clock.shift() ?? 2000,
+      spawnCommand: ((_command: string, commandArgs: string[]) => {
+        spawned.push(commandArgs);
+        return fakeChild("", 1, "Live preflight retryable failure: fetch failed\n");
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      lstat: missingStat,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      realpath: (path) => Promise.resolve(pathToString(path)),
+      appendFile: (path, text) => {
+        const key = pathToString(path);
+        writes.set(key, `${writes.get(key) ?? ""}${textToString(text)}`);
+        return Promise.resolve();
+      },
+      writeFile: (path, text) => {
+        writes.set(pathToString(path), textToString(text));
+        return Promise.resolve();
+      },
+    });
+
+    expect(exitCode).toBe(2);
+    expect(spawned.filter((args) => isPreflightCommand(args))).toHaveLength(1);
+    expect(spawned.filter((args) => !isPreflightCommand(args))).toHaveLength(0);
+    const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/preflight-retry-wall-clock-test/summary.json");
+    expect(summary).toMatchObject({ stopped: "unmet_coverage_goal" });
+    expect(writes.has("/repo/logs/live-supervisor/preflight-retry-wall-clock-test/cycle-0001-bot-preflight-attempt-1.command.json")).toBe(true);
   });
 
   it("caps actor command timers to Node's maximum delay", async () => {
@@ -1430,6 +2417,17 @@ describe("scenario planning", () => {
     });
   });
 
+  it("auto-plans fresh order skip targets through the two-pass scenario", () => {
+    const ledger = createCoverageLedger(["tester_fresh_order_skip"]);
+    const choice = chooseScenario({ scenario: "auto", targetOutcomes: ["tester_fresh_order_skip"] }, ledger);
+
+    expect(choice).toMatchObject({
+      kind: "scenario",
+      scenario: { name: "tester-fresh-skip-two-pass" },
+      targetOutcomes: ["tester_fresh_order_skip"],
+    });
+  });
+
   it("records unsupported explicit goals as full terminal classifications", async () => {
     const writes = new Map<string, string>();
     const args = parseArgs([
@@ -1456,7 +2454,7 @@ describe("scenario planning", () => {
     expect(exitCode).toBe(2);
     const incident = jsonArtifact(writes, "/repo/logs/live-supervisor/unsupported-test/cycle-0001-incident.json");
     const classification = recordAt(incident["classification"], "incident classification");
-    expect(classification).toMatchObject({ actor: "preflight", outcome: "unknown", terminal: true });
+    expect(classification).toMatchObject({ actor: "preflight", outcome: "unsupported_scenario", terminal: true });
     expect(classification["txHashes"]).toEqual([]);
     expect(recordAt(classification["evidence"], "incident classification evidence")).toMatchObject({
       recordsAccepted: 0,
@@ -1467,7 +2465,7 @@ describe("scenario planning", () => {
       timedOut: false,
     });
     const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/unsupported-test/summary.json");
-    expect(recordAt(summary["aggregateCounts"], "summary aggregate counts")).toMatchObject({ unknown: 1 });
+    expect(recordAt(summary["aggregateCounts"], "summary aggregate counts")).toMatchObject({ unsupported_scenario: 1 });
   });
 
   it("plans remaining target outcomes after earlier targets are covered", () => {
@@ -1539,6 +2537,136 @@ describe("deterministic incident handling", () => {
     expect(summaryArtifacts).toContain("logs/live-supervisor/unmet-coverage-test/cycle-0001-bot.stdout.ndjson");
     expect(summaryArtifacts).toContain("logs/live-supervisor/unmet-coverage-test/cycle-0001-bot.stderr.log");
     expect(summaryArtifacts).toContain("logs/live-supervisor/unmet-coverage-test/cycle-0001-bot.command.json");
+  });
+
+  it("treats unmet explicit target outcomes at max wall-clock as logical incidents", async () => {
+    const writes = new Map<string, string>();
+    const args = parseArgs([
+      "--bot-config", "config/bot-testnet.json",
+      "--tester-config", "config/tester-testnet.json",
+      "--out-dir", "logs/live-supervisor/unmet-wall-clock-test",
+      "--scenario", "bot-only",
+      "--target-outcome", "bot_match_committed",
+      "--max-wall-clock-seconds", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) });
+    const clock = [0, 2000];
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      now: () => clock.shift() ?? 2000,
+      spawnCommand: (() => {
+        throw new Error("actor should not start after wall-clock expiry");
+      }),
+      spawnSyncCommand: ignoredChecker(true) as never,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      appendFile: (path, text) => {
+        const key = pathToString(path);
+        writes.set(key, `${writes.get(key) ?? ""}${textToString(text)}`);
+        return Promise.resolve();
+      },
+      writeFile: (path, text) => {
+        writes.set(pathToString(path), textToString(text));
+        return Promise.resolve();
+      },
+    });
+
+    expect(exitCode).toBe(2);
+    const incident = jsonArtifact(writes, "/repo/logs/live-supervisor/unmet-wall-clock-test/cycle-0001-incident.json");
+    expect(incident).toMatchObject({ unmetGoals: ["bot_match_committed"] });
+    expect(recordAt(incident["classification"], "incident classification")).toMatchObject({
+      actor: "preflight",
+      outcome: "unmet_coverage_goal",
+      terminal: true,
+      reason: "bounded wall-clock budget ended before observing requested outcomes: bot_match_committed",
+    });
+    const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/unmet-wall-clock-test/summary.json");
+    expect(summary).toMatchObject({ stopped: "unmet_coverage_goal" });
+    expect(recordAt(summary["aggregateCounts"], "summary aggregate counts")).toMatchObject({ unmet_coverage_goal: 1 });
+  });
+
+  it("uses the last attempted cycle for wall-clock unmet coverage incidents", async () => {
+    const writes = new Map<string, string>();
+    const args = parseArgs([
+      "--bot-config", "config/bot-testnet.json",
+      "--tester-config", "config/tester-testnet.json",
+      "--out-dir", "logs/live-supervisor/unmet-wall-clock-after-cycle-test",
+      "--scenario", "bot-only",
+      "--target-outcome", "bot_match_committed",
+      "--max-wall-clock-seconds", "1",
+      "--max-cycles", "2",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) });
+    const clock = [0, 0, 0, 0, 0, 0, 0, 2000];
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      now: () => clock.shift() ?? 2000,
+      spawnCommand: ((_command: string, commandArgs: string[]) => isPreflightCommand(commandArgs) ? fakeSuccessfulPreflightChild() : fakeChild(JSON.stringify(botEvent("bot.decision.skipped", {
+        reason: "no_actions",
+        actions: emptyActions(),
+      })))) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      appendFile: (path, text) => {
+        const key = pathToString(path);
+        writes.set(key, `${writes.get(key) ?? ""}${textToString(text)}`);
+        return Promise.resolve();
+      },
+      writeFile: (path, text) => {
+        writes.set(pathToString(path), textToString(text));
+        return Promise.resolve();
+      },
+    });
+
+    expect(exitCode).toBe(2);
+    const incident = jsonArtifact(writes, "/repo/logs/live-supervisor/unmet-wall-clock-after-cycle-test/cycle-0001-incident.json");
+    expect(incident).toMatchObject({ cycleIndex: 1, unmetGoals: ["bot_match_committed"] });
+    expect(writes.has("/repo/logs/live-supervisor/unmet-wall-clock-after-cycle-test/cycle-0002-incident.json")).toBe(false);
+  });
+
+  it("does not start another command after the wall-clock budget expires mid-cycle", async () => {
+    const writes = new Map<string, string>();
+    const spawned: string[][] = [];
+    const args = parseArgs([
+      "--bot-config", "config/bot-testnet.json",
+      "--tester-config", "config/tester-testnet.json",
+      "--out-dir", "logs/live-supervisor/mid-cycle-wall-clock-test",
+      "--scenario", "standard-cycle",
+      "--target-outcome", "bot_match_committed",
+      "--max-wall-clock-seconds", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: ignoredChecker(true) });
+    const clock = [0, 0, 0, 0, 0, 2000];
+
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      now: () => clock.shift() ?? 2000,
+      spawnCommand: ((_command: string, commandArgs: string[]) => {
+        spawned.push(commandArgs);
+        return fakeSuccessfulPreflightChild();
+      }) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      appendFile: (path, text) => {
+        const key = pathToString(path);
+        writes.set(key, `${writes.get(key) ?? ""}${textToString(text)}`);
+        return Promise.resolve();
+      },
+      writeFile: (path, text) => {
+        writes.set(pathToString(path), textToString(text));
+        return Promise.resolve();
+      },
+    });
+
+    expect(exitCode).toBe(2);
+    expect(spawned).toHaveLength(1);
+    expect(spawned[0]).toContain("tester-1");
+    const incident = jsonArtifact(writes, "/repo/logs/live-supervisor/mid-cycle-wall-clock-test/cycle-0001-incident.json");
+    expect(incident).toMatchObject({ cycleIndex: 1, unmetGoals: ["bot_match_committed"] });
   });
 
   it("treats repeated target outcomes as one explicit contract", async () => {
@@ -1616,6 +2744,7 @@ describe("deterministic incident handling", () => {
     expect(exitCode).toBe(2);
     const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/target-ledger-test/summary.json");
     expect(recordAt(summary["coverage"], "coverage")["goals"]).toEqual(["tester_estimated_too_small_skip"]);
+    expect(summary).toMatchObject({ txCreatingTxHashCount: 1, txCreatingOutcomeCount: 1 });
   });
 
   it("keeps successful preflight probes out of aggregate outcome counts", async () => {
@@ -1651,6 +2780,79 @@ describe("deterministic incident handling", () => {
     expect(exitCode).toBe(0);
     const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/preflight-summary-test/summary.json");
     expect(recordAt(summary["aggregateCounts"], "summary aggregate counts")).toEqual({ bot_no_action_skip: 1 });
+  });
+
+  it("summarizes safe preflight balances and selected tester scenario", async () => {
+    const writes = new Map<string, string>();
+    const args = parseArgs([
+      "--out-dir", "logs/live-supervisor/preflight-state-summary-test",
+      "--scenario", "tester-fresh-skip-two-pass",
+      "--target-outcome", "tester_order_created",
+      "--stop-after-tx-count", "1",
+      "--max-cycles", "1",
+    ]);
+    const plan = resolvePlan(args, "/repo", { spawnSyncCommand: selectiveIgnoredChecker(new Set([
+      "logs/live-supervisor/preflight-state-summary-test",
+      "config/bot-testnet.json",
+      "config/tester-testnet.json",
+    ])) });
+
+    let testerRuns = 0;
+    const exitCode = await supervise(args, plan, {
+      skipBuiltRuntimeCheck: true,
+      spawnCommand: ((_command: string, commandArgs: string[]) => isPreflightCommand(commandArgs)
+        ? fakePreflightChild({ ckbAvailable: "2853.99897309", ickbAvailable: "250838.31219989" })
+        : fakeChild(JSON.stringify((testerRuns += 1) === 1
+          ? {
+              startTime: "now",
+              actions: {
+                requestedTesterScenario: "multi-order-limit-orders",
+                testerScenario: "two-ickb-to-ckb-limit-orders",
+                newOrders: [
+                  { giveIckb: "10", takeCkb: "9", fee: "0.1" },
+                  { giveIckb: "10", takeCkb: "9", fee: "0.1" },
+                ],
+                orderCount: 2,
+                cancelledOrders: 0,
+              },
+              txHash: txHash("81"),
+              ElapsedSeconds: 1,
+            }
+          : { skip: { reason: "fresh-matchable-order", txHash: txHash("81") } }))) as never,
+      spawnSyncCommand: ignoredChecker(true) as never,
+      stat: missingStat,
+      mkdir: () => Promise.resolve(undefined),
+      appendFile: () => Promise.resolve(),
+      writeFile: (path, text) => {
+        writes.set(pathToString(path), textToString(text));
+        return Promise.resolve();
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/preflight-state-summary-test/summary.json");
+    expect(summary["preflightState"]).toEqual([
+      {
+        cycleIndex: 1,
+        actor: "tester",
+        step: "tester-pass-1",
+        selectedTesterScenario: "auto",
+        balances: {
+          CKB: { available: "2853.99897309" },
+          ICKB: { available: "250838.31219989" },
+        },
+      },
+      {
+        cycleIndex: 1,
+        actor: "tester",
+        step: "tester-pass-2",
+        selectedTesterScenario: "auto",
+        balances: {
+          CKB: { available: "2853.99897309" },
+          ICKB: { available: "250838.31219989" },
+        },
+      },
+    ]);
   });
 
   it("keeps default coverage goals best-effort at max cycles", async () => {
@@ -1739,7 +2941,21 @@ describe("deterministic incident handling", () => {
 
     expect(exitCode).toBe(0);
     expect([...writes.keys()].some((path) => path.endsWith("incident.json"))).toBe(false);
-    expect(writes.get("/repo/logs/live-supervisor/stop-after-tx-test/summary.json")).toContain("stop_after_tx_count");
+    const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/stop-after-tx-test/summary.json");
+    expect(summary).toMatchObject({
+      stopped: "stop_after_tx_count",
+      txCreatingTxHashCount: 1,
+      txCreatingOutcomeCount: 1,
+      testerOrderEvidence: [
+        {
+          outcome: "tester_order_created",
+          txHashes: [txHash("44")],
+          orderCount: 1,
+          cancelledOrders: 0,
+          orders: [{ direction: "ckb-to-ickb", giveCkb: "10", takeIckb: "9", fee: "0.1", dust: false }],
+        },
+      ],
+    });
   });
 
   it("does not count skip reference hashes toward stop-after-tx-count", async () => {
@@ -1776,7 +2992,7 @@ describe("deterministic incident handling", () => {
 
     expect(exitCode).toBe(0);
     const summary = jsonArtifact(writes, "/repo/logs/live-supervisor/skip-hash-stop-test/summary.json");
-    expect(summary).toMatchObject({ stopped: "max_cycles" });
+    expect(summary).toMatchObject({ stopped: "max_cycles", txCreatingTxHashCount: 0, txCreatingOutcomeCount: 0 });
     expect(recordAt(summary["txHashesByOutcome"], "summary tx hashes")).toEqual({
       tester_fresh_order_skip: [txHash("44")],
     });
@@ -1841,10 +3057,32 @@ function isPreflightCommand(args: string[]): boolean {
 }
 
 function fakeSuccessfulPreflightChild(): ReturnType<typeof fakeChild> {
-  return fakeChild(JSON.stringify({ chain: "testnet" }));
+  return fakeChild(JSON.stringify({ chain: "testnet", bounded: true, maxIterations: 1 }));
+}
+
+function fakePreflightChild({ ckbAvailable, ickbAvailable }: { ckbAvailable: string; ickbAvailable: string }): ReturnType<typeof fakeChild> {
+  return fakeChild(JSON.stringify({
+    chain: "testnet",
+    bounded: true,
+    maxIterations: 1,
+    balances: {
+      CKB: { available: ckbAvailable },
+      ICKB: { available: ickbAvailable },
+    },
+  }));
 }
 
 function fakeChild(stdout: string, status = 0): EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: () => boolean;
+};
+function fakeChild(stdout: string, status: number, stderr: string): EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: () => boolean;
+};
+function fakeChild(stdout: string, status = 0, stderr = ""): EventEmitter & {
   stdout: EventEmitter;
   stderr: EventEmitter;
   kill: () => boolean;
@@ -1859,6 +3097,9 @@ function fakeChild(stdout: string, status = 0): EventEmitter & {
   child.kill = (): boolean => true;
   queueMicrotask(() => {
     child.stdout.emit("data", Buffer.from(`${stdout}\n`));
+    if (stderr !== "") {
+      child.stderr.emit("data", Buffer.from(stderr));
+    }
     child.emit("close", status, null);
   });
   return child;

--- a/apps/supervisor/src/index.ts
+++ b/apps/supervisor/src/index.ts
@@ -1311,21 +1311,15 @@ function classifyBotResult(
     const failed = lifecycle.record;
     const outcome = stringField(failed, "outcome");
     const phase = stringField(failed, "phase");
-    if (outcome === "timeout_after_broadcast") {
+    if (outcome === "timeout_after_broadcast" || outcome === "post_broadcast_unresolved" || outcome === "terminal_rejection") {
       if (!hasValidTxHash(failed)) {
         return { ...base, outcome: "malformed_evidence", terminal: true, reason: "bot post-broadcast transaction failure evidence did not include a valid tx hash", publicState };
       }
-      return { ...base, outcome: "confirmation_timeout", terminal: true, reason: "bot tx confirmation timed out", publicState };
-    }
-    if (outcome === "post_broadcast_unresolved") {
-      if (!hasValidTxHash(failed)) {
-        return { ...base, outcome: "malformed_evidence", terminal: true, reason: "bot post-broadcast transaction failure evidence did not include a valid tx hash", publicState };
+      if (outcome === "timeout_after_broadcast") {
+        return { ...base, outcome: "confirmation_timeout", terminal: true, reason: "bot tx confirmation timed out", publicState };
       }
-      return { ...base, outcome: "post_broadcast_unresolved", terminal: true, reason: "bot tx remained unresolved after broadcast", publicState };
-    }
-    if (outcome === "terminal_rejection") {
-      if (!hasValidTxHash(failed)) {
-        return { ...base, outcome: "malformed_evidence", terminal: true, reason: "bot post-broadcast transaction failure evidence did not include a valid tx hash", publicState };
+      if (outcome === "post_broadcast_unresolved") {
+        return { ...base, outcome: "post_broadcast_unresolved", terminal: true, reason: "bot tx remained unresolved after broadcast", publicState };
       }
       return { ...base, outcome: "terminal_chain_rejection", terminal: true, reason: "bot tx reached terminal chain rejection", publicState };
     }
@@ -2069,10 +2063,9 @@ function emptyActions(): ActionCounts {
 function extractTxHashes(records: Record<string, unknown>[]): string[] {
   const hashes = new Set<string>();
   for (const record of records) {
-    addValidTxHash(hashes, record["txHash"]);
-    addValidTxHash(hashes, recordField(record, "error")?.["txHash"]);
-    const skip = recordField(record, "skip");
-    addValidTxHash(hashes, skip?.["txHash"]);
+    addValidTxHash(hashes, stringField(record, "txHash"));
+    addValidTxHash(hashes, stringField(recordField(record, "error"), "txHash"));
+    addValidTxHash(hashes, stringField(recordField(record, "skip"), "txHash"));
   }
   return [...hashes];
 }

--- a/apps/supervisor/src/index.ts
+++ b/apps/supervisor/src/index.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { existsSync } from "node:fs";
 import { appendFile, lstat, mkdir, realpath, stat, writeFile } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { isAbsolute, join, parse, relative, resolve, sep } from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -25,6 +25,7 @@ export const OUTCOME_KINDS = [
   "tester_reserve_skip",
   "tester_deterministic_pre_broadcast_error",
   "bot_no_action_skip",
+  "bot_retryable_error",
   "bot_reserve_skip",
   "bot_match_committed",
   "bot_match_plus_deposit_committed",
@@ -38,17 +39,18 @@ export const OUTCOME_KINDS = [
   "post_broadcast_unresolved",
   "wrong_chain",
   "malformed_evidence",
-  "secret_leak_sentinel",
   "command_timeout",
+  "preflight_retryable_error",
   "nonzero_exit",
   "unmet_coverage_goal",
+  "unsupported_scenario",
   "unknown",
 ] as const;
 
 export type OutcomeKind = typeof OUTCOME_KINDS[number];
 export type Actor = "bot" | "tester";
 export type ScenarioName = "auto" | "standard-cycle" | "tester-only" | "bot-only" | "tester-fresh-skip-two-pass";
-export type TesterScenario = "auto" | "random-order" | "sdk-conversion" | "extra-large-limit-order" | "multi-order-limit-orders" | "two-ckb-to-ickb-limit-orders" | "all-ckb-limit-order" | "ickb-to-ckb-limit-order" | "two-ickb-to-ckb-limit-orders" | "mixed-direction-limit-orders" | "dust-ckb-conversion" | "dust-ickb-conversion";
+export type TesterScenario = "auto" | "random-order" | "sdk-conversion" | "extra-large-limit-order" | "multi-order-limit-orders" | "two-ckb-to-ickb-limit-orders" | "all-ckb-limit-order" | "ickb-to-ckb-limit-order" | "bounded-ickb-to-ckb-limit-order" | "two-ickb-to-ckb-limit-orders" | "mixed-direction-limit-orders" | "dust-ckb-conversion" | "dust-ickb-conversion";
 type TesterDirection = "ckb-to-ickb" | "ickb-to-ckb";
 
 interface ScenarioStep {
@@ -127,10 +129,13 @@ export interface Classification {
     exitStatus: number | null;
     signal: NodeJS.Signals | null;
     timedOut: boolean;
+    stdoutTruncated: boolean;
+    stderrTruncated: boolean;
   };
   actions?: ActionCounts;
   skipReason?: string;
   publicState?: PublicStateAssumption;
+  testerOrder?: TesterOrderEvidence;
 }
 
 interface TesterEvidenceExpectation {
@@ -157,6 +162,38 @@ export interface PublicStateAssumption {
   readyPoolDepositCount?: number;
   nearReadyPoolDepositCount?: number;
   futurePoolDepositCount?: number;
+}
+
+export interface TesterOrderEvidence {
+  requestedTesterScenario?: string;
+  testerScenario?: string;
+  orderCount: number;
+  collectedOrders?: number;
+  cancelledOrders?: number;
+  orders: TesterOrderSummary[];
+}
+
+export interface TesterOrderSummary {
+  direction?: TesterDirection;
+  giveCkb?: string;
+  takeIckb?: string;
+  giveIckb?: string;
+  takeCkb?: string;
+  fee?: string;
+  feeNumerator?: string;
+  feeBase?: string;
+  dust: boolean;
+}
+
+export interface PreflightStateSummary {
+  cycleIndex: number;
+  actor: Actor;
+  step: string;
+  selectedTesterScenario?: TesterScenario;
+  balances?: {
+    CKB?: { available: string };
+    ICKB?: { available: string };
+  };
 }
 
 export interface CoverageLedger {
@@ -267,14 +304,14 @@ const SCENARIOS: ScenarioDefinition[] = [
   {
     name: "tester-fresh-skip-two-pass",
     steps: [
-      { actor: "tester", label: "tester-pass-1", testerScenario: "multi-order-limit-orders" },
+      { actor: "tester", label: "tester-pass-1" },
       { actor: "tester", label: "tester-pass-2" },
     ],
     targetOutcomes: [
       "tester_order_created",
       "tester_fresh_order_skip",
     ],
-    reason: "run the same tester twice so a multi-order first pass can leave a fresh owned order for skip coverage",
+    reason: "run the same tester twice so a fundable first pass can leave a fresh owned order for skip coverage",
   },
 ];
 
@@ -317,7 +354,7 @@ export function usage(): string {
     "  --max-wall-clock-seconds <n>",
     "  --stop-after-tx-count <n>",
     "  --scenario auto|standard-cycle|tester-only|bot-only|tester-fresh-skip-two-pass",
-    "  --tester-scenario auto|random-order|sdk-conversion|extra-large-limit-order|multi-order-limit-orders|two-ckb-to-ickb-limit-orders|all-ckb-limit-order|ickb-to-ckb-limit-order|two-ickb-to-ckb-limit-orders|mixed-direction-limit-orders|dust-ckb-conversion|dust-ickb-conversion",
+    "  --tester-scenario auto|random-order|sdk-conversion|extra-large-limit-order|multi-order-limit-orders|two-ckb-to-ickb-limit-orders|all-ckb-limit-order|ickb-to-ckb-limit-order|bounded-ickb-to-ckb-limit-order|two-ickb-to-ckb-limit-orders|mixed-direction-limit-orders|dust-ckb-conversion|dust-ickb-conversion",
     "  --tester-fee <n>                    Default: 1",
     "  --tester-fee-base <n>               Default: 100000",
     "  --target-outcome <outcome>           Repeatable; planner prefers these first",
@@ -424,16 +461,16 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
 export function resolvePlan(args: ParsedArgs, rootDir = repoRoot, dependencies: Dependencies = {}): SupervisorPlan {
   const runId = createRunId();
-  const outDir = insideRepoPath(rootDir, args.outDir ?? `logs/live-supervisor/${runId}`, "Output directory");
-  const relativeOutDir = relative(rootDir, outDir);
+  const outDir = resolveConfiguredPath(rootDir, args.outDir ?? `logs/live-supervisor/${runId}`, "Output directory");
+  const relativeOutDir = displayPath(rootDir, outDir);
   const botConfigPath = args.botConfigPath === undefined
     ? undefined
     : insideRepoPath(rootDir, args.botConfigPath, "Bot config path");
   const testerConfigPath = args.testerConfigPath === undefined
     ? undefined
     : insideRepoPath(rootDir, args.testerConfigPath, "Tester config path");
-  assertSupervisorOutputDirectory(relativeOutDir);
-  if (!isIgnoredPath(rootDir, relativeOutDir, dependencies)) {
+  assertSupervisorOutputDirectory(outDir, relativeOutDir);
+  if (isInside(rootDir, outDir) && !isIgnoredPath(rootDir, relativeOutDir, dependencies)) {
     throw new Error(`Refusing to write non-ignored supervisor output directory: ${relativeOutDir}`);
   }
   if (botConfigPath !== undefined) {
@@ -515,17 +552,11 @@ export function classifyActorResult(
       exitStatus: result.status,
       signal: result.signal,
       timedOut: result.timedOut,
+      stdoutTruncated: result.stdoutTruncated,
+      stderrTruncated: result.stderrTruncated,
     },
   };
 
-  if (containsSecretLeak(result.stdout) || containsSecretLeak(result.stderr)) {
-    return {
-      ...base,
-      outcome: "secret_leak_sentinel",
-      terminal: true,
-      reason: "stdout or stderr contained a secret-shaped field",
-    };
-  }
   if (result.timedOut) {
     return {
       ...base,
@@ -540,6 +571,16 @@ export function classifyActorResult(
       outcome: "nonzero_exit",
       terminal: true,
       reason: `${actor} failed to spawn: ${result.spawnError}`,
+    };
+  }
+  if (result.stdoutTruncated || result.stderrTruncated) {
+    return {
+      ...base,
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: result.stdoutTruncated
+        ? "stdout evidence exceeded supervisor capture limit"
+        : "stderr evidence exceeded supervisor capture limit",
     };
   }
   if (evidence.malformedLines.length > 0) {
@@ -610,7 +651,11 @@ export function chooseScenario(args: Pick<ParsedArgs, "scenario" | "targetOutcom
   const candidates = SCENARIOS
     .filter((scenario) => scenario.targetOutcomes.includes(underCovered))
     .sort((left, right) => left.steps.length - right.steps.length);
-  const scenario = candidates.find((candidate) => !ledger.attempts.some((attempt) => attempt.scenario === candidate.name))
+  const preferred = underCovered === "tester_fresh_order_skip"
+    ? candidates.find((candidate) => candidate.name === "tester-fresh-skip-two-pass")
+    : undefined;
+  const scenario = preferred
+    ?? candidates.find((candidate) => !ledger.attempts.some((attempt) => attempt.scenario === candidate.name))
     ?? candidates[0];
   if (scenario === undefined) {
     return {
@@ -661,6 +706,9 @@ export async function supervise(args: ParsedArgs, plan: SupervisorPlan, dependen
 
 async function superviseOnce(args: ParsedArgs, plan: SupervisorPlan, dependencies: Dependencies = {}): Promise<number> {
   const startedAt = now(dependencies);
+  const wallClockDeadline = args.maxWallClockSeconds === undefined
+    ? undefined
+    : startedAt + args.maxWallClockSeconds * 1000;
   if (!args.dryRun && dependencies.skipBuiltRuntimeCheck !== true) {
     assertBuiltRuntime(plan, dependencies);
   }
@@ -668,8 +716,24 @@ async function superviseOnce(args: ParsedArgs, plan: SupervisorPlan, dependencie
   const ledger = createCoverageLedger(explicitCoverageGoals(args).length > 0 ? explicitCoverageGoals(args) : DEFAULT_COVERAGE_GOALS);
   const classifications = new Array<Classification>();
   const artifacts = new Array<string>();
+  const preflightState = new Array<PreflightStateSummary>();
   let txCount = 0;
   let latestPublicState: PublicStateAssumption | undefined;
+
+  const stopForExpiredWallClock = async (incidentCycleIndex: number): Promise<number | undefined> => {
+    if (args.maxWallClockSeconds === undefined || now(dependencies) - startedAt < args.maxWallClockSeconds * 1000) {
+      return undefined;
+    }
+    const unmetGoals = unmetExplicitGoals(args, ledger);
+    if (unmetGoals.length > 0) {
+      const incident = await writeUnmetCoverageIncident(plan, incidentCycleIndex, unmetGoals, ledger, artifacts, dependencies, "bounded wall-clock budget");
+      classifications.push(incident.classification);
+      await writeSummary(plan, ledger, classifications, artifacts, preflightState, latestPublicState, incident.classification.outcome, dependencies);
+      return STOP_EXIT_CODE;
+    }
+    await writeSummary(plan, ledger, classifications, artifacts, preflightState, latestPublicState, "max_wall_clock_seconds", dependencies);
+    return 0;
+  };
 
   if (args.dryRun) {
     const dryRunResult = await runDryRun(plan, ledger, dependencies);
@@ -677,9 +741,9 @@ async function superviseOnce(args: ParsedArgs, plan: SupervisorPlan, dependencie
   }
 
   for (let cycleIndex = 1; cycleIndex <= args.maxCycles; cycleIndex += 1) {
-    if (args.maxWallClockSeconds !== undefined && now(dependencies) - startedAt >= args.maxWallClockSeconds * 1000) {
-      await writeSummary(plan, ledger, classifications, artifacts, latestPublicState, "max_wall_clock_seconds", dependencies);
-      return 0;
+    const cycleWallClockStop = await stopForExpiredWallClock(Math.max(1, cycleIndex - 1));
+    if (cycleWallClockStop !== undefined) {
+      return cycleWallClockStop;
     }
 
     const choice = chooseScenario(args, ledger);
@@ -689,7 +753,7 @@ async function superviseOnce(args: ParsedArgs, plan: SupervisorPlan, dependencie
       classifications.push(classification);
       const incident = unsupportedIncident(plan, cycleIndex, choice, ledger, classification);
       await writeJsonArtifact(plan, `cycle-${padCycle(cycleIndex)}-incident.json`, incident, artifacts, dependencies);
-      await writeSummary(plan, ledger, classifications, artifacts, latestPublicState, "unsupported_scenario", dependencies);
+      await writeSummary(plan, ledger, classifications, artifacts, preflightState, latestPublicState, "unsupported_scenario", dependencies);
       return STOP_EXIT_CODE;
     }
 
@@ -701,20 +765,68 @@ async function superviseOnce(args: ParsedArgs, plan: SupervisorPlan, dependencie
       reason: choice.reason,
     }, dependencies);
 
+    const preflightReports = new Map<string, Record<string, unknown>>();
     for (const step of choice.scenario.steps) {
-      const result = await runPreflight(step.actor, plan, cycleIndex, stepLabel(step), dependencies);
-      artifacts.push(...await writeCommandArtifacts(plan, cycleIndex, `${stepLabel(step)}-preflight`, result, dependencies));
-      const classification = classifyActorResult("preflight", result);
+      const wallClockStop = await stopForExpiredWallClock(cycleIndex);
+      if (wallClockStop !== undefined) {
+        return wallClockStop;
+      }
+      const firstTimeoutMs = commandTimeoutMs(plan, wallClockDeadline, dependencies);
+      if (firstTimeoutMs === undefined) {
+        const stop = await stopForExpiredWallClock(cycleIndex);
+        return stop ?? STOP_EXIT_CODE;
+      }
+      const firstResult = await runPreflight(step.actor, plan, cycleIndex, stepLabel(step), dependencies, firstTimeoutMs);
+      const firstClassification = classifyActorResult("preflight", firstResult);
+      const shouldRetryPreflight = firstClassification.outcome === "preflight_retryable_error";
+      if (shouldRetryPreflight) {
+        artifacts.push(...await writeCommandArtifacts(plan, cycleIndex, `${stepLabel(step)}-preflight-attempt-1`, firstResult, dependencies));
+        const retryWallClockStop = await stopForExpiredWallClock(cycleIndex);
+        if (retryWallClockStop !== undefined) {
+          return retryWallClockStop;
+        }
+      }
+      let result = firstResult;
+      if (shouldRetryPreflight) {
+        const retryTimeoutMs = commandTimeoutMs(plan, wallClockDeadline, dependencies);
+        if (retryTimeoutMs === undefined) {
+          const stop = await stopForExpiredWallClock(cycleIndex);
+          return stop ?? STOP_EXIT_CODE;
+        }
+        result = await runPreflight(step.actor, plan, cycleIndex, stepLabel(step), dependencies, retryTimeoutMs);
+      }
+      artifacts.push(...await writeCommandArtifacts(
+        plan,
+        cycleIndex,
+        `${stepLabel(step)}-preflight${shouldRetryPreflight ? "-attempt-2" : ""}`,
+        result,
+        dependencies,
+      ));
+      const classification = shouldRetryPreflight ? classifyActorResult("preflight", result) : firstClassification;
       if (classification.terminal) {
         classifications.push(classification);
         await writeIncident(plan, cycleIndex, step.actor, choice, classification, result, ledger, artifacts, dependencies);
-        await writeSummary(plan, ledger, classifications, artifacts, latestPublicState, classification.outcome, dependencies);
+        await writeSummary(plan, ledger, classifications, artifacts, preflightState, latestPublicState, classification.outcome, dependencies);
         return STOP_EXIT_CODE;
+      }
+      const report = parsePreflightEvidence(result.stdout).records[0];
+      if (report !== undefined) {
+        preflightReports.set(stepLabel(step), report);
+        preflightState.push(preflightStateSummary(cycleIndex, step, plan, choice.targetOutcomes, report));
       }
     }
 
     for (const step of choice.scenario.steps) {
-      const result = await runActor(step, plan, choice.targetOutcomes, dependencies);
+      const wallClockStop = await stopForExpiredWallClock(cycleIndex);
+      if (wallClockStop !== undefined) {
+        return wallClockStop;
+      }
+      const actorTimeoutMs = commandTimeoutMs(plan, wallClockDeadline, dependencies);
+      if (actorTimeoutMs === undefined) {
+        const stop = await stopForExpiredWallClock(cycleIndex);
+        return stop ?? STOP_EXIT_CODE;
+      }
+      const result = await runActor(step, plan, choice.targetOutcomes, actorTimeoutMs, dependencies);
       artifacts.push(...await writeCommandArtifacts(plan, cycleIndex, stepLabel(step), result, dependencies));
       const classification = classifyActorResult(step.actor, result, step.actor === "tester" ? testerEvidenceExpectation(plan, step) : undefined);
       classifications.push(classification);
@@ -734,11 +846,11 @@ async function superviseOnce(args: ParsedArgs, plan: SupervisorPlan, dependencie
 
       if (classification.terminal) {
         const incident = await writeIncident(plan, cycleIndex, step.actor, choice, classification, result, ledger, artifacts, dependencies);
-        await writeSummary(plan, ledger, classifications, artifacts, latestPublicState, incident.classification.outcome, dependencies);
+        await writeSummary(plan, ledger, classifications, artifacts, preflightState, latestPublicState, incident.classification.outcome, dependencies);
         return classification.outcome === "nonzero_exit" ? 1 : STOP_EXIT_CODE;
       }
       if (args.stopAfterTxCount !== undefined && txCount >= args.stopAfterTxCount) {
-        await writeSummary(plan, ledger, classifications, artifacts, latestPublicState, "stop_after_tx_count", dependencies);
+        await writeSummary(plan, ledger, classifications, artifacts, preflightState, latestPublicState, "stop_after_tx_count", dependencies);
         return 0;
       }
     }
@@ -746,13 +858,13 @@ async function superviseOnce(args: ParsedArgs, plan: SupervisorPlan, dependencie
 
   const unmetGoals = unmetExplicitGoals(args, ledger);
   if (unmetGoals.length > 0) {
-    const incident = await writeUnmetCoverageIncident(plan, args.maxCycles, unmetGoals, ledger, artifacts, dependencies);
+    const incident = await writeUnmetCoverageIncident(plan, args.maxCycles, unmetGoals, ledger, artifacts, dependencies, "bounded cycle budget");
     classifications.push(incident.classification);
-    await writeSummary(plan, ledger, classifications, artifacts, latestPublicState, incident.classification.outcome, dependencies);
+    await writeSummary(plan, ledger, classifications, artifacts, preflightState, latestPublicState, incident.classification.outcome, dependencies);
     return STOP_EXIT_CODE;
   }
 
-  await writeSummary(plan, ledger, classifications, artifacts, latestPublicState, "max_cycles", dependencies);
+  await writeSummary(plan, ledger, classifications, artifacts, preflightState, latestPublicState, "max_cycles", dependencies);
   return 0;
 }
 
@@ -792,7 +904,7 @@ async function runDryRun(plan: SupervisorPlan, ledger: CoverageLedger, dependenc
     classifications.push(classification);
     const incident = unsupportedIncident(plan, 1, choice, ledger, classification);
     await writeJsonArtifact(plan, "dry-run-incident.json", incident, artifacts, dependencies);
-    await writeSummary(plan, ledger, classifications, artifacts, undefined, "unsupported_scenario", dependencies);
+    await writeSummary(plan, ledger, classifications, artifacts, [], undefined, "unsupported_scenario", dependencies);
     return STOP_EXIT_CODE;
   }
 
@@ -830,7 +942,7 @@ async function runDryRun(plan: SupervisorPlan, ledger: CoverageLedger, dependenc
     artifacts.push(...await writeCommandArtifacts(plan, 1, `dry-run-${sample.actor}`, sample.result, dependencies));
   }
 
-  await writeSummary(plan, ledger, classifications, artifacts, latestPublicState, "dry_run", dependencies);
+  await writeSummary(plan, ledger, classifications, artifacts, [], latestPublicState, "dry_run", dependencies);
   return 0;
 }
 
@@ -852,14 +964,15 @@ async function prepareOutputDirectory(plan: SupervisorPlan, dependencies: Depend
 
 async function assertNoSymlinkedOutputAncestors(plan: SupervisorPlan, dependencies: Dependencies): Promise<void> {
   const lstatFn = dependencies.lstat ?? lstat;
-  const parts = plan.relativeOutDir.split("/").filter((part) => part !== "");
-  let current = plan.rootDir;
+  const base = isInside(plan.rootDir, plan.outDir) ? plan.rootDir : parse(plan.outDir).root;
+  const parts = relative(base, plan.outDir).split(sep).filter((part) => part !== "");
+  let current = base;
   for (const part of parts) {
     current = join(current, part);
     try {
       const stats = await lstatFn(current);
       if (stats.isSymbolicLink()) {
-        throw new Error(`Refusing to write supervisor artifacts through symlinked path: ${relative(plan.rootDir, current)}`);
+        throw new Error(`Refusing to write supervisor artifacts through symlinked path: ${displayPath(plan.rootDir, current)}`);
       }
     } catch (error) {
       if (isNotFoundError(error)) {
@@ -885,8 +998,7 @@ async function assertRealOutputDirectory(plan: SupervisorPlan, dependencies: Dep
     }
     throw error;
   }
-  const relativeOutDir = relative(realRoot, realOutDir);
-  if (relativeOutDir.startsWith("..") || isAbsolute(relativeOutDir)) {
+  if (isInside(plan.rootDir, plan.outDir) && !isInside(realRoot, realOutDir)) {
     throw new Error("Supervisor output directory must stay inside the repo");
   }
 }
@@ -913,24 +1025,25 @@ function assertBuiltRuntime(plan: SupervisorPlan, dependencies: Dependencies): v
   }
 }
 
-async function runPreflight(actor: Actor, plan: SupervisorPlan, cycleIndex: number, role: string, dependencies: Dependencies): Promise<CommandResult> {
+async function runPreflight(actor: Actor, plan: SupervisorPlan, cycleIndex: number, role: string, dependencies: Dependencies, timeoutMs: number): Promise<CommandResult> {
   const configPath = actor === "bot" ? plan.botConfigPath : plan.testerConfigPath;
   if (configPath === undefined) {
     throw new Error(`Missing ${actor} config path`);
   }
   await assertNoSymlinkedConfigPath(plan.rootDir, configPath, `${actor} config path`, dependencies);
-  return runCommand({
+  const spec: Parameters<typeof runCommand>[0] = {
     actor: "preflight",
     command: process.execPath,
     args: ["scripts/ickb-live-preflight.mjs", "--config", configPath, "--role", `${role}-${String(cycleIndex)}`],
     cwd: plan.rootDir,
     env: liveActorEnv({ INIT_CWD: plan.rootDir }),
     inheritEnv: false,
-    timeoutMs: plan.commandTimeoutSeconds * 1000,
-  }, dependencies);
+    timeoutMs,
+  };
+  return await runCommand(spec, dependencies);
 }
 
-async function runActor(step: ScenarioStep, plan: SupervisorPlan, targetOutcomes: OutcomeKind[], dependencies: Dependencies): Promise<CommandResult> {
+async function runActor(step: ScenarioStep, plan: SupervisorPlan, targetOutcomes: OutcomeKind[], timeoutMs: number, dependencies: Dependencies): Promise<CommandResult> {
   const actor = step.actor;
   const configPath = actor === "bot" ? plan.botConfigPath : plan.testerConfigPath;
   if (configPath === undefined) {
@@ -950,20 +1063,39 @@ async function runActor(step: ScenarioStep, plan: SupervisorPlan, targetOutcomes
       ...(actor === "tester" ? testerEnv(plan, targetOutcomes, step) : {}),
     }),
     inheritEnv: false,
-    timeoutMs: plan.commandTimeoutSeconds * 1000,
+    timeoutMs,
   }, dependencies);
 }
 
 function testerEnv(plan: SupervisorPlan, targetOutcomes: OutcomeKind[], step: ScenarioStep): Record<string, string> {
   return {
-    TESTER_SCENARIO: testerScenarioForTargets(plan.testerScenario, plan.testerScenarioExplicit, targetOutcomes, step.testerScenario),
+    TESTER_SCENARIO: testerScenarioForTargets(plan.testerScenario, plan.testerScenarioExplicit, targetOutcomes, step),
     ...(plan.testerFeeExplicit ? { TESTER_FEE: plan.testerFee } : {}),
     ...(plan.testerFeeBaseExplicit ? { TESTER_FEE_BASE: plan.testerFeeBase } : {}),
   };
 }
 
+function commandTimeoutMs(plan: SupervisorPlan, wallClockDeadline: number | undefined, dependencies: Dependencies): number | undefined {
+  const configuredTimeoutMs = plan.commandTimeoutSeconds * 1000;
+  if (wallClockDeadline === undefined) {
+    return configuredTimeoutMs;
+  }
+  const remainingMs = wallClockDeadline - now(dependencies);
+  return remainingMs <= 0 ? undefined : Math.min(configuredTimeoutMs, remainingMs);
+}
+
+function preflightNonzeroOutcome(stderr: string): OutcomeKind {
+  if (stderr.includes("Invalid") && stderr.includes("chain identity")) {
+    return "wrong_chain";
+  }
+  if (stderr.includes("Live preflight retryable failure:")) {
+    return "preflight_retryable_error";
+  }
+  return "nonzero_exit";
+}
+
 function testerEvidenceExpectation(plan: SupervisorPlan, step: ScenarioStep): TesterEvidenceExpectation | undefined {
-  const scenario = testerScenarioForTargets(plan.testerScenario, plan.testerScenarioExplicit, [], step.testerScenario);
+  const scenario = testerScenarioForTargets(plan.testerScenario, plan.testerScenarioExplicit, [], step);
   return scenario !== "auto" ? { scenario } : undefined;
 }
 
@@ -971,11 +1103,12 @@ function testerScenarioForTargets(
   configuredScenario: TesterScenario,
   testerScenarioExplicit: boolean,
   targetOutcomes: OutcomeKind[],
-  stepScenario: TesterScenario | undefined,
+  step: ScenarioStep,
 ): TesterScenario {
   if (testerScenarioExplicit || configuredScenario !== "auto") {
     return configuredScenario;
   }
+  const stepScenario = step.testerScenario;
   if (stepScenario !== undefined) {
     return stepScenario;
   }
@@ -983,6 +1116,39 @@ function testerScenarioForTargets(
     return "sdk-conversion";
   }
   return configuredScenario;
+}
+
+function preflightAvailableBalanceText(preflightReport: Record<string, unknown> | undefined, asset: "CKB" | "ICKB"): string | undefined {
+  const balances = optionalRecordField(preflightReport, "balances");
+  const balance = optionalRecordField(balances, asset);
+  return stringField(balance, "available");
+}
+
+function preflightStateSummary(
+  cycleIndex: number,
+  step: ScenarioStep,
+  plan: SupervisorPlan,
+  targetOutcomes: OutcomeKind[],
+  preflightReport: Record<string, unknown>,
+): PreflightStateSummary {
+  const summary: PreflightStateSummary = {
+    cycleIndex,
+    actor: step.actor,
+    step: stepLabel(step),
+  };
+  const ckbAvailable = preflightAvailableBalanceText(preflightReport, "CKB");
+  const ickbAvailable = preflightAvailableBalanceText(preflightReport, "ICKB");
+  if (ckbAvailable !== undefined || ickbAvailable !== undefined) {
+    summary.balances = {
+      ...(ckbAvailable === undefined ? {} : { CKB: { available: ckbAvailable } }),
+      ...(ickbAvailable === undefined ? {} : { ICKB: { available: ickbAvailable } }),
+    };
+  }
+  if (step.actor === "tester") {
+    const selectedTesterScenario = testerScenarioForTargets(plan.testerScenario, plan.testerScenarioExplicit, targetOutcomes, step);
+    summary.selectedTesterScenario = selectedTesterScenario;
+  }
+  return summary;
 }
 
 function stepLabel(step: ScenarioStep): string {
@@ -1103,9 +1269,9 @@ function classifyPreflightResult(
   if (result.status !== 0) {
     return {
       ...base,
-      outcome: result.stderr.includes("Invalid") && result.stderr.includes("chain identity") ? "wrong_chain" : "nonzero_exit",
+      outcome: preflightNonzeroOutcome(result.stderr),
       terminal: true,
-      reason: boundedText(safeArtifactText(result.stderr), 240) || "preflight command exited nonzero",
+      reason: boundedText(result.stderr, 240) || "preflight command exited nonzero",
     };
   }
   const report = evidence.records[0];
@@ -1115,6 +1281,14 @@ function classifyPreflightResult(
       outcome: "malformed_evidence",
       terminal: true,
       reason: "preflight did not return a JSON report",
+    };
+  }
+  if (report["bounded"] !== true || report["maxIterations"] !== 1) {
+    return {
+      ...base,
+      outcome: "malformed_evidence",
+      terminal: true,
+      reason: "preflight config is not bounded to one iteration",
     };
   }
   return {
@@ -1132,20 +1306,30 @@ function classifyBotResult(
 ): Classification {
   const botRecords = evidence.records.filter(isBotRecord);
   const publicState = latestPublicState(botRecords);
-  const failed = lastRecordOfType(botRecords, "bot.transaction.failed");
-  if (failed !== undefined) {
+  const lifecycle = lastRecordOfTypes(botRecords, ["bot.transaction.failed", "bot.transaction.committed"]);
+  if (lifecycle?.type === "bot.transaction.failed") {
+    const failed = lifecycle.record;
     const outcome = stringField(failed, "outcome");
     const phase = stringField(failed, "phase");
     if (outcome === "timeout_after_broadcast") {
+      if (!hasValidTxHash(failed)) {
+        return { ...base, outcome: "malformed_evidence", terminal: true, reason: "bot post-broadcast transaction failure evidence did not include a valid tx hash", publicState };
+      }
       return { ...base, outcome: "confirmation_timeout", terminal: true, reason: "bot tx confirmation timed out", publicState };
     }
     if (outcome === "post_broadcast_unresolved") {
+      if (!hasValidTxHash(failed)) {
+        return { ...base, outcome: "malformed_evidence", terminal: true, reason: "bot post-broadcast transaction failure evidence did not include a valid tx hash", publicState };
+      }
       return { ...base, outcome: "post_broadcast_unresolved", terminal: true, reason: "bot tx remained unresolved after broadcast", publicState };
     }
     if (outcome === "terminal_rejection") {
+      if (!hasValidTxHash(failed)) {
+        return { ...base, outcome: "malformed_evidence", terminal: true, reason: "bot post-broadcast transaction failure evidence did not include a valid tx hash", publicState };
+      }
       return { ...base, outcome: "terminal_chain_rejection", terminal: true, reason: "bot tx reached terminal chain rejection", publicState };
     }
-    if (phase === "pre_broadcast") {
+    if (phase === "pre_broadcast" && (failed["retryable"] !== true || failed["terminal"] !== false)) {
       return { ...base, outcome: "unknown", terminal: true, reason: "bot pre-broadcast transaction failure", publicState };
     }
   }
@@ -1163,6 +1347,17 @@ function classifyBotResult(
     };
   }
 
+  const iterationFailure = lastRecordOfType(botRecords, "bot.iteration.failed");
+  if (iterationFailure !== undefined && iterationFailure["retryable"] === true && iterationFailure["terminal"] === true) {
+    return {
+      ...base,
+      outcome: "bot_retryable_error",
+      terminal: true,
+      reason: "bot reported terminal retryable iteration failure",
+      publicState,
+    };
+  }
+
   if (result.status !== 0) {
     return {
       ...base,
@@ -1173,12 +1368,15 @@ function classifyBotResult(
     };
   }
 
-  const committed = lastRecordOfType(botRecords, "bot.transaction.committed");
-  if (committed !== undefined) {
+  if (lifecycle?.type === "bot.transaction.committed") {
+    const committed = lifecycle.record;
     if (!hasValidTxHash(committed)) {
       return { ...base, outcome: "malformed_evidence", terminal: true, reason: "bot committed transaction evidence did not include a valid tx hash", publicState };
     }
-    const actions = latestBotActions(botRecords) ?? emptyActions();
+    const actions = latestBotActions(botRecords, numberField(committed, "iterationId"));
+    if (actions === undefined) {
+      return { ...base, outcome: "malformed_evidence", terminal: true, reason: "bot committed transaction evidence did not include matching built action evidence", publicState };
+    }
     return {
       ...base,
       outcome: classifyBotCommittedActions(actions),
@@ -1213,6 +1411,16 @@ function classifyBotResult(
       publicState,
     };
   }
+
+  if (iterationFailure !== undefined && iterationFailure["retryable"] === true && iterationFailure["terminal"] === false) {
+    return {
+      ...base,
+      outcome: "bot_retryable_error",
+      terminal: false,
+      reason: "bot reported retryable iteration failure",
+      publicState,
+    };
+  }
   return { ...base, outcome: "unknown", terminal: true, reason: "bot produced no classifiable terminal evidence", publicState };
 }
 
@@ -1227,8 +1435,9 @@ function classifyTesterResult(
   if (latest !== undefined) {
     const error = latest["error"];
     if (error !== undefined) {
-      if (hasTimeoutError(error)) {
-        return { ...base, outcome: "confirmation_timeout", terminal: true, reason: "tester transaction confirmation timed out" };
+      const transactionFailure = classifyTesterTransactionFailure(error, latest);
+      if (transactionFailure !== undefined) {
+        return { ...base, ...transactionFailure };
       }
       if (isTesterFundingError(error)) {
         return { ...base, outcome: "low_capital_stop", terminal: true, reason: "tester reported insufficient funds" };
@@ -1251,6 +1460,9 @@ function classifyTesterResult(
       if (reason === "fresh-matchable-order") {
         return { ...base, outcome: "tester_fresh_order_skip", terminal: false, reason: "tester skipped fresh matchable order", skipReason: reason };
       }
+      if (reason === "matchable-order-transaction-missing") {
+        return { ...base, outcome: "tester_fresh_order_skip", terminal: false, reason: "tester skipped because matchable order transaction was not readable yet", skipReason: reason };
+      }
       if (reason === "sampled-amount-too-small") {
         return { ...base, outcome: "tester_sampled_too_small_skip", terminal: false, reason: "tester sampled amount too small", skipReason: reason };
       }
@@ -1272,14 +1484,82 @@ function classifyTesterResult(
       if (expectationFailure !== undefined) {
         return { ...base, outcome: "tester_deterministic_pre_broadcast_error", terminal: true, reason: expectationFailure };
       }
+      const testerOrder = testerOrderEvidence(actions);
       const conversionKind = stringField(recordField(actions ?? {}, "conversion"), "kind");
-      if (conversionKind !== undefined) {
-        return { ...base, outcome: "tester_conversion_created", terminal: false, reason: "tester created a direct conversion transaction" };
+      if (testerOrder === undefined && conversionKind === undefined) {
+        return { ...base, outcome: "malformed_evidence", terminal: true, reason: "tester committed transaction evidence did not include action evidence" };
       }
-      return { ...base, outcome: "tester_order_created", terminal: false, reason: "tester created an order transaction" };
+      if (conversionKind !== undefined) {
+        return {
+          ...base,
+          outcome: "tester_conversion_created",
+          terminal: false,
+          reason: "tester created a direct conversion transaction",
+          ...(testerOrder === undefined ? {} : { testerOrder }),
+        };
+      }
+      return {
+        ...base,
+        outcome: "tester_order_created",
+        terminal: false,
+        reason: "tester created an order transaction",
+        ...(testerOrder === undefined ? {} : { testerOrder }),
+      };
     }
   }
   return { ...base, outcome: "unknown", terminal: true, reason: "tester produced no classifiable terminal evidence" };
+}
+
+function testerOrderEvidence(actions: Record<string, unknown> | undefined): TesterOrderEvidence | undefined {
+  if (actions === undefined) {
+    return undefined;
+  }
+  const orders = testerOrderSummaries(actions);
+  if (orders.length === 0) {
+    return undefined;
+  }
+  return {
+    ...(stringField(actions, "requestedTesterScenario") === undefined ? {} : { requestedTesterScenario: stringField(actions, "requestedTesterScenario") }),
+    ...(stringField(actions, "testerScenario") === undefined ? {} : { testerScenario: stringField(actions, "testerScenario") }),
+    orderCount: numberField(actions, "orderCount") ?? orders.length,
+    ...(numberField(actions, "collectedOrders") === undefined ? {} : { collectedOrders: numberField(actions, "collectedOrders") }),
+    ...(numberField(actions, "cancelledOrders") === undefined ? {} : { cancelledOrders: numberField(actions, "cancelledOrders") }),
+    orders,
+  };
+}
+
+function testerOrderSummaries(actions: Record<string, unknown>): TesterOrderSummary[] {
+  const newOrders = arrayField(actions, "newOrders");
+  if (newOrders !== undefined) {
+    return newOrders.flatMap((order) => {
+      const summary = testerOrderSummary(order);
+      return summary === undefined ? [] : [summary];
+    });
+  }
+  const newOrder = recordField(actions, "newOrder");
+  const summary = testerOrderSummary(newOrder);
+  return summary === undefined ? [] : [summary];
+}
+
+function testerOrderSummary(order: unknown): TesterOrderSummary | undefined {
+  if (!isRecord(order)) {
+    return undefined;
+  }
+  const giveCkb = stringField(order, "giveCkb");
+  const takeIckb = stringField(order, "takeIckb");
+  const giveIckb = stringField(order, "giveIckb");
+  const takeCkb = stringField(order, "takeCkb");
+  return {
+    ...(orderDirection(order) === undefined ? {} : { direction: orderDirection(order) }),
+    ...(giveCkb === undefined ? {} : { giveCkb }),
+    ...(takeIckb === undefined ? {} : { takeIckb }),
+    ...(giveIckb === undefined ? {} : { giveIckb }),
+    ...(takeCkb === undefined ? {} : { takeCkb }),
+    ...(stringField(order, "fee") === undefined ? {} : { fee: stringField(order, "fee") }),
+    ...(stringField(order, "feeNumerator") === undefined ? {} : { feeNumerator: stringField(order, "feeNumerator") }),
+    ...(stringField(order, "feeBase") === undefined ? {} : { feeBase: stringField(order, "feeBase") }),
+    dust: giveCkb === "0.00000001" || giveIckb === "0.00000001",
+  };
 }
 
 function validateTesterEvidenceExpectation(actions: Record<string, unknown> | undefined, expectation: TesterEvidenceExpectation | undefined): string | undefined {
@@ -1398,27 +1678,27 @@ function isSdkConversionTesterScenario(scenario: TesterScenario): boolean {
 }
 
 function isIckbToCkbTesterScenario(scenario: TesterScenario): boolean {
-  return scenario === "ickb-to-ckb-limit-order" || scenario === "two-ickb-to-ckb-limit-orders" || scenario === "dust-ickb-conversion";
+  return scenario === "ickb-to-ckb-limit-order" || scenario === "bounded-ickb-to-ckb-limit-order" || scenario === "two-ickb-to-ckb-limit-orders" || scenario === "dust-ickb-conversion";
 }
 
 function classifyBotCommittedActions(actions: ActionCounts): OutcomeKind {
   if (actions.matchedOrders > 0 && actions.deposits > 0) {
     return "bot_match_plus_deposit_committed";
   }
-  if (actions.matchedOrders > 0) {
-    return "bot_match_committed";
+  if (actions.withdrawalRequests > 0) {
+    return "bot_withdrawal_request_committed";
   }
   if (actions.completedDeposits > 0) {
     return "bot_receipt_completion_committed";
   }
-  if (actions.deposits > 0) {
-    return "bot_deposit_only_committed";
-  }
-  if (actions.withdrawalRequests > 0) {
-    return "bot_withdrawal_request_committed";
-  }
   if (actions.withdrawals > 0) {
     return "bot_withdrawal_completion_committed";
+  }
+  if (actions.matchedOrders > 0) {
+    return "bot_match_committed";
+  }
+  if (actions.deposits > 0) {
+    return "bot_deposit_only_committed";
   }
   return "unknown";
 }
@@ -1426,7 +1706,7 @@ function classifyBotCommittedActions(actions: ActionCounts): OutcomeKind {
 function unsupportedClassification(choice: UnsupportedScenarioChoice): Classification {
   return {
     actor: "preflight",
-    outcome: "unknown",
+    outcome: "unsupported_scenario",
     terminal: true,
     reason: choice.reason,
     txHashes: [],
@@ -1437,6 +1717,8 @@ function unsupportedClassification(choice: UnsupportedScenarioChoice): Classific
       exitStatus: null,
       signal: null,
       timedOut: false,
+      stdoutTruncated: false,
+      stderrTruncated: false,
     },
   };
 }
@@ -1456,12 +1738,13 @@ async function writeUnmetCoverageIncident(
   ledger: CoverageLedger,
   artifacts: string[],
   dependencies: Dependencies,
+  budgetLabel: string,
 ): Promise<IncidentArtifact> {
   const classification: Classification = {
     actor: "preflight",
     outcome: "unmet_coverage_goal",
     terminal: true,
-    reason: `bounded cycle budget ended before observing requested outcomes: ${unmetGoals.join(", ")}`,
+    reason: `${budgetLabel} ended before observing requested outcomes: ${unmetGoals.join(", ")}`,
     txHashes: [],
     evidence: {
       recordsAccepted: 0,
@@ -1470,6 +1753,8 @@ async function writeUnmetCoverageIncident(
       exitStatus: null,
       signal: null,
       timedOut: false,
+      stdoutTruncated: false,
+      stderrTruncated: false,
     },
   };
   const relativePath = await writeJsonArtifact(plan, `cycle-${padCycle(cycleIndex)}-incident.json`, {
@@ -1502,7 +1787,7 @@ async function writeIncident(
     actor,
     scenario: choice.scenario.name,
     targetOutcomes: choice.targetOutcomes,
-    command: redactedCommandShape(plan, result),
+    command: commandShape(plan, result),
     exit: {
       spawnError: result.spawnError,
       status: result.status,
@@ -1514,8 +1799,8 @@ async function writeIncident(
     },
     classification,
     coverage: coverageSummary(ledger),
-    stdoutExcerpt: boundedText(safeArtifactText(result.stdout), 4000),
-    stderrExcerpt: boundedText(safeArtifactText(result.stderr), 4000),
+    stdoutExcerpt: boundedText(result.stdout, 4000),
+    stderrExcerpt: boundedText(result.stderr, 4000),
     artifacts,
     suggestedNextAction: suggestedNextAction(classification),
   }, artifacts, dependencies);
@@ -1545,6 +1830,7 @@ async function writeSummary(
   ledger: CoverageLedger,
   classifications: Classification[],
   artifacts: string[],
+  preflightState: PreflightStateSummary[],
   latestPublicState: PublicStateAssumption | undefined,
   stopReason: string,
   dependencies: Dependencies,
@@ -1555,7 +1841,11 @@ async function writeSummary(
     artifacts,
     aggregateCounts: aggregateClassifications(classifications),
     txHashesByOutcome: txHashesByOutcome(classifications),
+    txCreatingTxHashCount: txCreatingHashCountTotal(classifications),
+    txCreatingOutcomeCount: txCreatingOutcomeCount(classifications),
+    testerOrderEvidence: testerOrderEvidenceByOutcome(classifications),
     skipReasons: classifications.map((item) => item.skipReason).filter((item) => item !== undefined),
+    preflightState,
     scenarioAttempts: ledger.attempts,
     coverage: coverageSummary(ledger),
     publicVsOwnedStateAssumptions: latestPublicState ?? null,
@@ -1570,10 +1860,11 @@ async function writeCommandArtifacts(
   dependencies: Dependencies,
 ): Promise<string[]> {
   const base = `cycle-${padCycle(cycleIndex)}-${label}`;
-  const stdoutPath = await writeTextArtifact(plan, `${base}.stdout.ndjson`, safeArtifactText(result.stdout), dependencies);
-  const stderrPath = await writeTextArtifact(plan, `${base}.stderr.log`, safeArtifactText(result.stderr), dependencies);
+  const stdoutExtension = result.actor === "preflight" ? "json" : "ndjson";
+  const stdoutPath = await writeTextArtifact(plan, `${base}.stdout.${stdoutExtension}`, result.stdout, dependencies);
+  const stderrPath = await writeTextArtifact(plan, `${base}.stderr.log`, result.stderr, dependencies);
   const commandPath = await writeJsonArtifact(plan, `${base}.command.json`, {
-    command: redactedCommandShape(plan, result),
+    command: commandShape(plan, result),
     exit: {
       spawnError: result.spawnError,
       status: result.status,
@@ -1591,7 +1882,7 @@ async function writeTextArtifact(plan: SupervisorPlan, fileName: string, text: s
   const writeFileFn = dependencies.writeFile ?? writeFile;
   const artifactPath = join(plan.outDir, fileName);
   await writeFileFn(artifactPath, text);
-  return relative(plan.rootDir, artifactPath);
+  return displayPath(plan.rootDir, artifactPath);
 }
 
 async function writeJsonArtifact(
@@ -1604,7 +1895,7 @@ async function writeJsonArtifact(
   const writeFileFn = dependencies.writeFile ?? writeFile;
   const artifactPath = join(plan.outDir, fileName);
   await writeFileFn(artifactPath, `${JSON.stringify(value, jsonReplacer, 2)}\n`);
-  const relativePath = relative(plan.rootDir, artifactPath);
+  const relativePath = displayPath(plan.rootDir, artifactPath);
   if (!artifacts.includes(relativePath)) {
     artifacts.push(relativePath);
   }
@@ -1622,7 +1913,7 @@ async function appendSupervisorEvent(plan: SupervisorPlan, fields: Record<string
   }, jsonReplacer)}\n`);
 }
 
-function redactedCommandShape(plan: SupervisorPlan, result: CommandResult): Record<string, unknown> {
+function commandShape(plan: SupervisorPlan, result: CommandResult): Record<string, unknown> {
   return {
     command: result.command === process.execPath ? "node" : result.command,
     args: result.args.map((arg) => arg === plan.botConfigPath
@@ -1655,8 +1946,26 @@ function txHashesByOutcome(classifications: Classification[]): Record<string, st
   return Object.fromEntries(hashes);
 }
 
+function testerOrderEvidenceByOutcome(classifications: Classification[]): Array<TesterOrderEvidence & { outcome: OutcomeKind; txHashes: string[] }> {
+  return classifications.flatMap((classification) => classification.testerOrder === undefined
+    ? []
+    : [{
+        outcome: classification.outcome,
+        txHashes: classification.txHashes,
+        ...classification.testerOrder,
+      }]);
+}
+
 function txCreatingHashCount(classification: Classification): number {
   return TX_CREATING_OUTCOMES.has(classification.outcome) ? classification.txHashes.length : 0;
+}
+
+function txCreatingHashCountTotal(classifications: Classification[]): number {
+  return classifications.reduce((sum, classification) => sum + txCreatingHashCount(classification), 0);
+}
+
+function txCreatingOutcomeCount(classifications: Classification[]): number {
+  return classifications.filter((classification) => TX_CREATING_OUTCOMES.has(classification.outcome)).length;
 }
 
 function coverageSummary(ledger: CoverageLedger): Record<string, unknown> {
@@ -1674,22 +1983,19 @@ function suggestedNextAction(classification: Classification): string {
   if (classification.outcome === "confirmation_timeout" || classification.outcome === "post_broadcast_unresolved") {
     return "confirm the tx hash with a read-only chain query before sending any follow-up work";
   }
-  if (classification.outcome === "secret_leak_sentinel") {
-    return "stop, inspect artifacts for leakage, and rotate any exposed disposable key before relaunch";
-  }
   if (classification.outcome === "low_capital_stop") {
     return "fund the supervised account or provide an alternate ignored config, then rerun a bounded smoke";
   }
   return "inspect the incident bundle and run a review pass for material code changes before extended relaunch";
 }
 
-function latestBotActions(records: Record<string, unknown>[]): ActionCounts | undefined {
+function latestBotActions(records: Record<string, unknown>[], iterationId?: number): ActionCounts | undefined {
   for (let index = records.length - 1; index >= 0; index -= 1) {
     const record = records[index];
     if (record === undefined) {
       continue;
     }
-    if (stringField(record, "type") === "bot.transaction.built") {
+    if (stringField(record, "type") === "bot.transaction.built" && (iterationId === undefined || numberField(record, "iterationId") === iterationId)) {
       return actionCounts(record["actions"]);
     }
   }
@@ -1763,17 +2069,18 @@ function emptyActions(): ActionCounts {
 function extractTxHashes(records: Record<string, unknown>[]): string[] {
   const hashes = new Set<string>();
   for (const record of records) {
-    const txHash = record["txHash"];
-    if (typeof txHash === "string" && TX_HASH_PATTERN.test(txHash)) {
-      hashes.add(txHash);
-    }
+    addValidTxHash(hashes, record["txHash"]);
+    addValidTxHash(hashes, recordField(record, "error")?.["txHash"]);
     const skip = recordField(record, "skip");
-    const skipTxHash = skip?.["txHash"];
-    if (typeof skipTxHash === "string" && TX_HASH_PATTERN.test(skipTxHash)) {
-      hashes.add(skipTxHash);
-    }
+    addValidTxHash(hashes, skip?.["txHash"]);
   }
   return [...hashes];
+}
+
+function addValidTxHash(hashes: Set<string>, value: unknown): void {
+  if (typeof value === "string" && TX_HASH_PATTERN.test(value)) {
+    hashes.add(value);
+  }
 }
 
 function hasValidTxHash(record: Record<string, unknown>): boolean {
@@ -1781,23 +2088,8 @@ function hasValidTxHash(record: Record<string, unknown>): boolean {
   return typeof txHash === "string" && TX_HASH_PATTERN.test(txHash);
 }
 
-function containsSecretLeak(text: string): boolean {
-  return /["']?(private[-_]?key|mnemonic|seed[-_]?phrase)["']?\s*[:=]/iu.test(text) ||
-    /["']?rpc[-_]?url["']?\s*[:=]\s*["']?https?:\/\/[^\s"']*(?:@|[?&][^\s"']*=)/iu.test(text);
-}
-
-function containsTransactionLeak(text: string): boolean {
-  return /["']?(witnesses|cellDeps|headerDeps|inputs|outputs|outputsData)["']?\s*:\s*\[/iu.test(text);
-}
-
-export function safeArtifactText(text: string): string {
-  if (containsSecretLeak(text)) {
-    return "<redacted: secret-shaped output withheld by supervisor>\n";
-  }
-  if (containsTransactionLeak(text)) {
-    return "<redacted: transaction-shaped output withheld by supervisor>\n";
-  }
-  return text;
+function hasValidTxHashInRecordOrError(record: Record<string, unknown>): boolean {
+  return hasValidTxHash(record) || hasValidTxHash(recordField(record, "error") ?? {});
 }
 
 function minimalProcessEnv(env: NodeJS.ProcessEnv): Record<string, string> {
@@ -1810,15 +2102,28 @@ function minimalProcessEnv(env: NodeJS.ProcessEnv): Record<string, string> {
 function liveActorEnv(extra: Record<string, string>): Record<string, string> {
   return {
     ...minimalProcessEnv(process.env),
+    NODE_OPTIONS: "--disable-warning=DEP0040",
     ...extra,
   };
 }
 
-function hasTimeoutError(value: unknown): boolean {
+function classifyTesterTransactionFailure(value: unknown, record: Record<string, unknown>): Pick<Classification, "outcome" | "terminal" | "reason"> | undefined {
   if (!isRecord(value)) {
-    return false;
+    return undefined;
   }
-  return value["isTimeout"] === true || stringField(value, "name") === "TransactionConfirmationError";
+  if (stringField(value, "name") !== "TransactionConfirmationError") {
+    return undefined;
+  }
+  if (!hasValidTxHashInRecordOrError(record)) {
+    return { outcome: "malformed_evidence", terminal: true, reason: "tester transaction failure evidence did not include a valid tx hash" };
+  }
+  if (value["isTimeout"] === false) {
+    return { outcome: "terminal_chain_rejection", terminal: true, reason: "tester tx reached terminal chain rejection" };
+  }
+  if (value["isTimeout"] === true && "cause" in value) {
+    return { outcome: "post_broadcast_unresolved", terminal: true, reason: "tester tx remained unresolved after broadcast" };
+  }
+  return { outcome: "confirmation_timeout", terminal: true, reason: "tester transaction confirmation timed out" };
 }
 
 function isTesterFundingError(value: unknown): boolean {
@@ -1838,6 +2143,20 @@ function lastRecordOfType(records: Record<string, unknown>[], type: string): Rec
     }
     if (stringField(record, "type") === type) {
       return record;
+    }
+  }
+  return undefined;
+}
+
+function lastRecordOfTypes(records: Record<string, unknown>[], types: readonly string[]): { type: string; record: Record<string, unknown> } | undefined {
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index];
+    if (record === undefined) {
+      continue;
+    }
+    const type = stringField(record, "type");
+    if (type !== undefined && types.includes(type)) {
+      return { type, record };
     }
   }
   return undefined;
@@ -1898,6 +2217,7 @@ function parseTesterScenario(value: string): TesterScenario {
     value === "two-ckb-to-ickb-limit-orders" ||
     value === "all-ckb-limit-order" ||
     value === "ickb-to-ckb-limit-order" ||
+    value === "bounded-ickb-to-ckb-limit-order" ||
     value === "two-ickb-to-ckb-limit-orders" ||
     value === "mixed-direction-limit-orders" ||
     value === "dust-ckb-conversion" ||
@@ -1905,7 +2225,7 @@ function parseTesterScenario(value: string): TesterScenario {
   ) {
     return value;
   }
-  throw new Error("Invalid --tester-scenario: expected auto, random-order, sdk-conversion, extra-large-limit-order, multi-order-limit-orders, two-ckb-to-ickb-limit-orders, all-ckb-limit-order, ickb-to-ckb-limit-order, two-ickb-to-ckb-limit-orders, mixed-direction-limit-orders, dust-ckb-conversion, or dust-ickb-conversion");
+  throw new Error("Invalid --tester-scenario: expected auto, random-order, sdk-conversion, extra-large-limit-order, multi-order-limit-orders, two-ckb-to-ickb-limit-orders, all-ckb-limit-order, ickb-to-ckb-limit-order, bounded-ickb-to-ckb-limit-order, two-ickb-to-ckb-limit-orders, mixed-direction-limit-orders, dust-ckb-conversion, or dust-ickb-conversion");
 }
 
 function valueAfter(argv: string[], index: number, option: string): string {
@@ -1934,11 +2254,15 @@ function parseTesterFeeValue(value: string, flag: string): string {
   return value;
 }
 
-function insideRepoPath(rootDir: string, path: string, label: string): string {
+function resolveConfiguredPath(rootDir: string, path: string, label: string): string {
   if (path === "") {
     throw new Error(`${label} must not be empty`);
   }
-  const absolutePath = isAbsolute(path) ? path : resolve(rootDir, path);
+  return isAbsolute(path) ? resolve(path) : resolve(rootDir, path);
+}
+
+function insideRepoPath(rootDir: string, path: string, label: string): string {
+  const absolutePath = resolveConfiguredPath(rootDir, path, label);
   const relativePath = relative(rootDir, absolutePath);
   if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
     throw new Error(`${label} must stay inside the repo`);
@@ -1946,11 +2270,31 @@ function insideRepoPath(rootDir: string, path: string, label: string): string {
   return absolutePath;
 }
 
-function assertSupervisorOutputDirectory(relativeOutDir: string): void {
-  if (relativeOutDir === "logs/live-supervisor" || relativeOutDir.startsWith(SUPERVISOR_OUTPUT_ROOT)) {
+function assertSupervisorOutputDirectory(outDir: string, relativeOutDir: string): void {
+  if (
+    relativeOutDir === "logs/live-supervisor" ||
+    relativeOutDir.startsWith(SUPERVISOR_OUTPUT_ROOT) ||
+    isValidationRunOutputDirectory(outDir)
+  ) {
     return;
   }
-  throw new Error(`Supervisor output directory must be under ${SUPERVISOR_OUTPUT_ROOT}`);
+  throw new Error(`Supervisor output directory must be under ${SUPERVISOR_OUTPUT_ROOT} or a validation session run directory`);
+}
+
+function isValidationRunOutputDirectory(path: string): boolean {
+  const parts = path.split(/[\\/]+/u);
+  for (let index = 0; index < parts.length - 4; index += 1) {
+    if (
+      parts[index] === "validation" &&
+      parts[index + 2] === "chunks" &&
+      /^chunk-[0-9]{4}$/u.test(parts[index + 3] ?? "") &&
+      /^run-[0-9]{4}$/u.test(parts[index + 4] ?? "") &&
+      index + 5 === parts.length
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function assertIgnoredConfigPath(
@@ -1996,6 +2340,15 @@ function isIgnoredPath(rootDir: string, relativePath: string, dependencies: Depe
     encoding: "utf8",
   });
   return result.status === 0;
+}
+
+function isInside(rootDir: string, path: string): boolean {
+  const relativePath = relative(rootDir, path);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+function displayPath(rootDir: string, path: string): string {
+  return isInside(rootDir, path) ? relative(rootDir, path) : path;
 }
 
 export function createBoundedOutputCapture(): BoundedOutputCapture {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "live:preflight": "node scripts/ickb-live-preflight.mjs",
     "live:supervisor": "node apps/supervisor/dist/index.js",
     "live:supervisor:loop": "node scripts/ickb-supervisor-loop.mjs",
+    "live:supervisor:dynamic-loop": "node scripts/ickb-supervisor-dynamic-loop.mjs",
     "coworker:ask": "opencode run --pure --agent plan"
   },
   "engines": {

--- a/scripts/ickb-script-helpers.mjs
+++ b/scripts/ickb-script-helpers.mjs
@@ -1,0 +1,31 @@
+const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
+
+export function valueAfter(argv, index, flag) {
+  const value = argv[index];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+export function parsePositiveInteger(value, flag) {
+  if (!/^[1-9][0-9]*$/u.test(value)) {
+    throw new Error(`Invalid ${flag}: expected a positive integer`);
+  }
+  const parsed = BigInt(value);
+  if (parsed > MAX_SAFE_INTEGER) {
+    throw new Error(`Invalid ${flag}: expected a safe integer`);
+  }
+  return Number(parsed);
+}
+
+export function parseNonNegativeInteger(value, flag) {
+  if (!/^(0|[1-9][0-9]*)$/u.test(value)) {
+    throw new Error(`Invalid ${flag}: expected a non-negative integer`);
+  }
+  const parsed = BigInt(value);
+  if (parsed > MAX_SAFE_INTEGER) {
+    throw new Error(`Invalid ${flag}: expected a safe integer`);
+  }
+  return Number(parsed);
+}

--- a/scripts/ickb-supervisor-dynamic-loop.mjs
+++ b/scripts/ickb-supervisor-dynamic-loop.mjs
@@ -1,0 +1,524 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { appendFile, lstat, mkdir, stat, writeFile } from "node:fs/promises";
+import { isAbsolute, join, parse, relative, resolve, sep } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parseNonNegativeInteger, parsePositiveInteger, valueAfter } from "./ickb-script-helpers.mjs";
+import { DEFAULT_CHILD_TIMEOUT_SECONDS_VALUE as DEFAULT_SUPERVISOR_LOOP_CHILD_TIMEOUT_SECONDS } from "./ickb-supervisor-loop.mjs";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const CKB_UNIT = 100000000n;
+const DEFAULT_TESTER_CONFIG = "config/tester-testnet.json";
+const DEFAULT_PREFLIGHT_SCRIPT = "scripts/ickb-live-preflight.mjs";
+const DEFAULT_SUPERVISOR_LOOP_SCRIPT = "scripts/ickb-supervisor-loop.mjs";
+const DEFAULT_LOG_ROOT = "log";
+const DEFAULT_CHUNK_MAX_RUNS = 8;
+const DEFAULT_STABLE_LIMIT = 999;
+const DEFAULT_CHUNK_BACKOFF_SECONDS = 20;
+const DEFAULT_BETWEEN_CHUNKS_SECONDS = 20;
+const DEFAULT_CHILD_TIMEOUT_SECONDS = DEFAULT_SUPERVISOR_LOOP_CHILD_TIMEOUT_SECONDS;
+export const DEFAULT_CHILD_TIMEOUT_SECONDS_VALUE = DEFAULT_CHILD_TIMEOUT_SECONDS;
+const DEFAULT_COMMAND_TIMEOUT_SECONDS = 240;
+const DEFAULT_CHUNK_TIMEOUT_MARGIN_SECONDS = 60;
+const DEFAULT_PREFLIGHT_TIMEOUT_SECONDS = 120;
+const ALL_CKB_MIN_CKB = 3001n;
+const ICKB_STIMULUS_MIN_CKB = 2100n;
+
+export function parseArgs(argv) {
+  const args = {
+    help: false,
+    testerConfig: DEFAULT_TESTER_CONFIG,
+    preflightRole: "tester-dynamic-loop",
+    preflightScript: DEFAULT_PREFLIGHT_SCRIPT,
+    supervisorLoopScript: DEFAULT_SUPERVISOR_LOOP_SCRIPT,
+    chunkMaxRuns: DEFAULT_CHUNK_MAX_RUNS,
+    stableLimit: DEFAULT_STABLE_LIMIT,
+    chunkBackoffSeconds: DEFAULT_CHUNK_BACKOFF_SECONDS,
+    betweenChunksSeconds: DEFAULT_BETWEEN_CHUNKS_SECONDS,
+    childTimeoutSeconds: DEFAULT_CHILD_TIMEOUT_SECONDS,
+    commandTimeoutSeconds: DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    preflightTimeoutSeconds: DEFAULT_PREFLIGHT_TIMEOUT_SECONDS,
+    supervisorArgs: [],
+  };
+  let chunkTimeoutSecondsExplicit = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      args.supervisorArgs = argv.slice(index + 1);
+      break;
+    }
+    if (arg === "-h" || arg === "--help") {
+      args.help = true;
+      continue;
+    }
+    if (arg === "--tester-config") {
+      args.testerConfig = valueAfter(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--preflight-role") {
+      args.preflightRole = valueAfter(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--preflight-script") {
+      args.preflightScript = valueAfter(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--supervisor-loop-script") {
+      args.supervisorLoopScript = valueAfter(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--log-root") {
+      args.logRoot = valueAfter(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--session-root") {
+      args.sessionRoot = valueAfter(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--max-chunks") {
+      args.maxChunks = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--chunk-max-runs") {
+      args.chunkMaxRuns = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--stable-limit") {
+      args.stableLimit = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--chunk-backoff-seconds") {
+      args.chunkBackoffSeconds = parseNonNegativeInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--between-chunks-seconds") {
+      args.betweenChunksSeconds = parseNonNegativeInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--child-timeout-seconds") {
+      args.childTimeoutSeconds = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--command-timeout-seconds") {
+      args.commandTimeoutSeconds = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--chunk-timeout-seconds") {
+      args.chunkTimeoutSeconds = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
+      chunkTimeoutSecondsExplicit = true;
+      continue;
+    }
+    if (arg === "--preflight-timeout-seconds") {
+      args.preflightTimeoutSeconds = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (args.supervisorArgs.some((arg) => arg === "--out-dir" || arg.startsWith("--out-dir="))) {
+    throw new Error("Do not pass supervisor --out-dir; dynamic-loop owns the session chunk roots");
+  }
+  const minimumChunkTimeoutSeconds = supervisorLoopChunkTimeoutFloorSeconds(args);
+  if (chunkTimeoutSecondsExplicit) {
+    if (BigInt(args.chunkTimeoutSeconds) < minimumChunkTimeoutSeconds) {
+      throw new Error(`Invalid --chunk-timeout-seconds: expected at least ${minimumChunkTimeoutSeconds.toString()} seconds for this chunk shape`);
+    }
+  } else {
+    args.chunkTimeoutSeconds = Number(minimumChunkTimeoutSeconds);
+  }
+  return args;
+}
+
+export function usage() {
+  return [
+    "Usage: node scripts/ickb-supervisor-dynamic-loop.mjs [options]",
+    "Options:",
+    `  --tester-config <ignored-json-config>  Default: ${DEFAULT_TESTER_CONFIG}`,
+    `  --preflight-role <label>              Default: tester-dynamic-loop`,
+    `  --max-chunks <n>                      Default: unbounded`,
+    `  --chunk-max-runs <n>                  Default: ${String(DEFAULT_CHUNK_MAX_RUNS)}`,
+    `  --stable-limit <n>                    Default: ${String(DEFAULT_STABLE_LIMIT)}`,
+    `  --chunk-backoff-seconds <n>           Default: ${String(DEFAULT_CHUNK_BACKOFF_SECONDS)}`,
+    `  --between-chunks-seconds <n>          Default: ${String(DEFAULT_BETWEEN_CHUNKS_SECONDS)}`,
+    `  --child-timeout-seconds <n>           Default: ${String(DEFAULT_CHILD_TIMEOUT_SECONDS)}`,
+    `  --command-timeout-seconds <n>         Default: ${String(DEFAULT_COMMAND_TIMEOUT_SECONDS)}`,
+    `  --chunk-timeout-seconds <n>           Default: derived from chunk-max-runs, child-timeout, and backoff`,
+    `  --preflight-timeout-seconds <n>       Default: ${String(DEFAULT_PREFLIGHT_TIMEOUT_SECONDS)}`,
+    `  --preflight-script <path>             Default: ${DEFAULT_PREFLIGHT_SCRIPT}`,
+    `  --supervisor-loop-script <path>       Default: ${DEFAULT_SUPERVISOR_LOOP_SCRIPT}`,
+    `  --log-root <path>                     Default: ${DEFAULT_LOG_ROOT}/`,
+    "  --session-root <path>                 Default: <log-root>/validation/dynamic-<time>-<pid>",
+    "  -h, --help",
+    "  -- [supervisor-options]",
+    "Reads tester preflight balance summaries, chooses a fundable tester scenario, then runs bounded supervisor-loop chunks.",
+  ].join("\n");
+}
+
+function supervisorLoopChunkTimeoutFloorSeconds(args) {
+  return BigInt(args.chunkMaxRuns) * BigInt(args.childTimeoutSeconds) +
+    BigInt(Math.max(0, args.chunkMaxRuns - 1)) * BigInt(args.chunkBackoffSeconds) +
+    BigInt(DEFAULT_CHUNK_TIMEOUT_MARGIN_SECONDS);
+}
+
+export function fixed8DecimalToUnits(value) {
+  const match = /^(0|[1-9][0-9]*)(?:\.([0-9]{1,8}))?$/u.exec(value ?? "");
+  if (match === null) {
+    return undefined;
+  }
+  return BigInt(match[1]) * CKB_UNIT + BigInt((match[2] ?? "").padEnd(8, "0"));
+}
+
+export function chooseTesterScenario({ ckb, ickb }) {
+  if (ckb >= ALL_CKB_MIN_CKB * CKB_UNIT) {
+    return { scenario: "all-ckb-limit-order", feeArgs: [] };
+  }
+  if (ckb >= ICKB_STIMULUS_MIN_CKB * CKB_UNIT && ickb > 0n) {
+    return {
+      scenario: "ickb-to-ckb-limit-order",
+      feeArgs: ["--tester-fee", "1", "--tester-fee-base", "1000"],
+    };
+  }
+  return { scenario: "auto", feeArgs: [] };
+}
+
+export async function runDynamicSupervisorLoop({ argv, root = rootDir, dependencies = {}, io = {} }) {
+  const stdout = io.stdout ?? process.stdout;
+  const stderr = io.stderr ?? process.stderr;
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (error) {
+    stderr.write(`${errorMessage(error)}\n${usage()}\n`);
+    return 1;
+  }
+  if (args.help) {
+    stdout.write(`${usage()}\n`);
+    return 0;
+  }
+
+  let session;
+  try {
+    session = await prepareValidationSession(args, root, dependencies);
+    await writeLaunchArtifact(session, args, root, dependencies);
+    await writeOperatorEvent(session, {
+      type: "session_started",
+      sessionRoot: session.displaySessionRoot,
+      logRoot: session.displayLogRoot,
+    }, dependencies);
+  } catch (error) {
+    stderr.write(`${errorMessage(error)}\n${usage()}\n`);
+    return 1;
+  }
+
+  for (let chunkIndex = 1; args.maxChunks === undefined || chunkIndex <= args.maxChunks; chunkIndex += 1) {
+    const preflight = runTesterPreflight(args, root, dependencies);
+    if (!preflight.ok) {
+      const record = {
+        type: "preflight_failed",
+        chunkIndex,
+        status: preflight.status,
+        signal: preflight.signal,
+        reason: preflight.reason,
+      };
+      writeJsonLine(stdout, record);
+      await writeOperatorEvent(session, record, dependencies);
+      if (preflight.stderr) {
+        stderr.write(preflight.stderr);
+        await appendOperatorStderr(session, preflight.stderr, dependencies);
+      }
+      return typeof preflight.status === "number" ? preflight.status : 1;
+    }
+
+    const choice = chooseTesterScenario(preflight);
+    const selectedRecord = {
+      type: "selected",
+      chunkIndex,
+      testerCkbAvailable: preflight.ckbText,
+      testerIckbAvailable: preflight.ickbText,
+      testerScenario: choice.scenario,
+    };
+    writeJsonLine(stdout, selectedRecord);
+    await writeOperatorEvent(session, selectedRecord, dependencies);
+
+    const result = runSupervisorChunk(args, choice, root, dependencies, session, chunkIndex);
+    if (result.stdout) {
+      stdout.write(result.stdout);
+    }
+    if (result.stderr) {
+      stderr.write(result.stderr);
+      await appendOperatorStderr(session, result.stderr, dependencies);
+    }
+    const stopReason = supervisorLoopStopReason(result.stdout ?? "");
+    const finishedRecord = {
+      type: "chunk_finished",
+      chunkIndex,
+      outRoot: chunkOutRootDisplay(session, root, chunkIndex),
+      status: result.status,
+      signal: result.signal,
+      ...(stopReason === undefined ? {} : { supervisorLoopStopReason: stopReason }),
+    };
+    writeJsonLine(stdout, finishedRecord);
+    await writeOperatorEvent(session, finishedRecord, dependencies);
+    if (result.status !== 0) {
+      return typeof result.status === "number" ? result.status : 1;
+    }
+    if (stopReason === "tx_observed" || stopReason === "new_outcome") {
+      return 0;
+    }
+
+    if ((args.maxChunks === undefined || chunkIndex < args.maxChunks) && args.betweenChunksSeconds > 0) {
+      await sleepMs(args.betweenChunksSeconds * 1000, dependencies);
+    }
+  }
+
+  return 0;
+}
+
+function supervisorLoopStopReason(stdout) {
+  const reasons = [...stdout.matchAll(/^loop stopped reason=([^\s]+)/gmu)].map((match) => match[1]);
+  return reasons.at(-1);
+}
+
+function runTesterPreflight(args, root, dependencies) {
+  const result = runNode([
+    args.preflightScript,
+    "--config",
+    args.testerConfig,
+    "--role",
+    args.preflightRole,
+  ], root, dependencies, { timeout: args.preflightTimeoutSeconds * 1000 });
+  if (result.status !== 0) {
+    return { ok: false, status: result.status, signal: result.signal, stderr: result.stderr, reason: "preflight command failed" };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    return { ok: false, status: 1, signal: null, stderr: result.stderr, reason: "preflight returned invalid JSON" };
+  }
+  const ckbText = parsed?.balances?.CKB?.available;
+  const ickbText = parsed?.balances?.ICKB?.available;
+  const ckb = fixed8DecimalToUnits(ckbText);
+  const ickb = fixed8DecimalToUnits(ickbText);
+  if (ckb === undefined || ickb === undefined) {
+    return { ok: false, status: 1, signal: null, stderr: result.stderr, reason: "preflight balances missing or invalid" };
+  }
+  return { ok: true, ckb, ickb, ckbText, ickbText };
+}
+
+function runSupervisorChunk(args, choice, root, dependencies, session, chunkIndex) {
+  const chunkOutRoot = join(session.chunksDir, `chunk-${padChunk(chunkIndex)}`);
+  const testerScenarioArgs = choice.scenario === "auto" ? [] : ["--tester-scenario", choice.scenario];
+  return runNode([
+    args.supervisorLoopScript,
+    "--out-root", childPath(root, chunkOutRoot),
+    "--max-runs", String(args.chunkMaxRuns),
+    "--stable-limit", String(args.stableLimit),
+    "--backoff-seconds", String(args.chunkBackoffSeconds),
+    "--child-timeout-seconds", String(args.childTimeoutSeconds),
+    "--",
+    ...testerScenarioArgs,
+    "--max-cycles", "1",
+    "--command-timeout-seconds", String(args.commandTimeoutSeconds),
+    ...args.supervisorArgs,
+    ...choice.feeArgs,
+  ], root, dependencies, { timeout: args.chunkTimeoutSeconds * 1000 });
+}
+
+async function prepareValidationSession(args, root, dependencies) {
+  const now = dependencies.now ?? Date.now;
+  const pid = dependencies.pid ?? process.pid;
+  const logRoot = resolveConfiguredPath(root, args.logRoot ?? DEFAULT_LOG_ROOT, "--log-root");
+  const sessionRoot = resolveConfiguredPath(
+    root,
+    args.sessionRoot ?? join(logRoot, "validation", `dynamic-${String(Math.floor(now() / 1000))}-${String(pid)}`),
+    "--session-root",
+  );
+  assertContained(logRoot, sessionRoot, "--session-root");
+  assertValidationSessionShape(logRoot, sessionRoot);
+  await assertNoSymlinkedPath(logRoot, "log root", dependencies);
+  await assertNoSymlinkedPath(sessionRoot, "session root", dependencies);
+
+  const relativeSessionRoot = relative(root, sessionRoot);
+  if (!relativeSessionRoot.startsWith("..") && !isAbsolute(relativeSessionRoot) && !checkIgnored(root, relativeSessionRoot, dependencies)) {
+    throw new Error(`Refusing to write non-ignored validation session root: ${relativeSessionRoot}`);
+  }
+
+  const statFn = dependencies.stat ?? stat;
+  try {
+    await statFn(sessionRoot);
+    throw new Error(`Validation session root already exists: ${displayPath(root, sessionRoot)}`);
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error;
+    }
+  }
+
+  const mkdirFn = dependencies.mkdir ?? mkdir;
+  const operatorDir = join(sessionRoot, "operator");
+  const chunksDir = join(sessionRoot, "chunks");
+  await mkdirFn(operatorDir, { recursive: true });
+  await mkdirFn(chunksDir, { recursive: true });
+  return {
+    logRoot,
+    sessionRoot,
+    operatorDir,
+    chunksDir,
+    displayLogRoot: displayPath(root, logRoot),
+    displaySessionRoot: displayPath(root, sessionRoot),
+  };
+}
+
+async function writeLaunchArtifact(session, args, root, dependencies) {
+  const writeFileFn = dependencies.writeFile ?? writeFile;
+  const startedAt = new Date((dependencies.now ?? Date.now)()).toISOString();
+  await writeFileFn(join(session.operatorDir, "launch.json"), `${JSON.stringify({
+    version: 1,
+    app: "dynamic-supervisor-loop",
+    startedAt,
+    pid: dependencies.pid ?? process.pid,
+    root,
+    logRoot: session.displayLogRoot,
+    sessionRoot: session.displaySessionRoot,
+    options: {
+      testerConfig: args.testerConfig,
+      preflightRole: args.preflightRole,
+      preflightScript: args.preflightScript,
+      supervisorLoopScript: args.supervisorLoopScript,
+      maxChunks: args.maxChunks ?? null,
+      chunkMaxRuns: args.chunkMaxRuns,
+      stableLimit: args.stableLimit,
+      chunkBackoffSeconds: args.chunkBackoffSeconds,
+      betweenChunksSeconds: args.betweenChunksSeconds,
+      childTimeoutSeconds: args.childTimeoutSeconds,
+      commandTimeoutSeconds: args.commandTimeoutSeconds,
+      chunkTimeoutSeconds: args.chunkTimeoutSeconds,
+      preflightTimeoutSeconds: args.preflightTimeoutSeconds,
+      supervisorArgCount: args.supervisorArgs.length,
+    },
+  }, null, 2)}\n`);
+}
+
+async function writeOperatorEvent(session, record, dependencies) {
+  const appendFileFn = dependencies.appendFile ?? appendFile;
+  await appendFileFn(join(session.operatorDir, "events.ndjson"), `${JSON.stringify({
+    at: new Date((dependencies.now ?? Date.now)()).toISOString(),
+    ...record,
+  })}\n`);
+}
+
+async function appendOperatorStderr(session, text, dependencies) {
+  const appendFileFn = dependencies.appendFile ?? appendFile;
+  await appendFileFn(join(session.operatorDir, "stderr.log"), text);
+}
+
+function runNode(commandArgs, root, dependencies, options) {
+  const spawnSyncFn = dependencies.spawnSync ?? spawnSync;
+  return spawnSyncFn(process.execPath, commandArgs, {
+    cwd: root,
+    encoding: "utf8",
+    env: minimalProcessEnv(process.env),
+    maxBuffer: 1024 * 1024,
+    ...options,
+  });
+}
+
+async function sleepMs(ms, dependencies) {
+  if (dependencies.sleep !== undefined) {
+    await dependencies.sleep(ms);
+    return;
+  }
+  await sleep(ms);
+}
+
+function writeJsonLine(stream, record) {
+  stream.write(`${JSON.stringify({ at: new Date().toISOString(), ...record })}\n`);
+}
+
+function minimalProcessEnv(env) {
+  return Object.fromEntries(["PATH", "HOME", "LANG", "LC_ALL", "TERM"].flatMap((key) => {
+    const value = env[key];
+    return value === undefined ? [] : [[key, value]];
+  }));
+}
+
+function resolveConfiguredPath(root, value, flag) {
+  if (value === "") {
+    throw new Error(`${flag} must not be empty`);
+  }
+  return isAbsolute(value) ? resolve(value) : resolve(root, value);
+}
+
+function assertContained(root, candidate, label) {
+  const relationship = relative(root, candidate);
+  if (relationship === "" || relationship === ".." || relationship.startsWith(`..${sep}`) || isAbsolute(relationship)) {
+    throw new Error(`${label} must stay under --log-root`);
+  }
+}
+
+function assertValidationSessionShape(logRoot, sessionRoot) {
+  const parts = relative(logRoot, sessionRoot).split(sep).filter((part) => part !== "");
+  if (parts.length === 2 && parts[0] === "validation") {
+    return;
+  }
+  throw new Error("--session-root must be <log-root>/validation/<session>");
+}
+
+async function assertNoSymlinkedPath(path, label, dependencies) {
+  const lstatFn = dependencies.lstat ?? lstat;
+  const parsed = parse(path);
+  let current = parsed.root;
+  const parts = relative(parsed.root, path).split(sep).filter((part) => part !== "");
+  for (const part of parts) {
+    current = join(current, part);
+    try {
+      const stats = await lstatFn(current);
+      if (stats.isSymbolicLink()) {
+        throw new Error(`Refusing to use ${label} through symlinked path: ${current}`);
+      }
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
+function checkIgnored(root, relativePath, dependencies) {
+  if (dependencies.checkIgnored !== undefined) {
+    return dependencies.checkIgnored(relativePath);
+  }
+  const result = spawnSync("git", ["-C", root, "check-ignore", "--", relativePath], { encoding: "utf8" });
+  return result.status === 0;
+}
+
+function childPath(root, path) {
+  const relativePath = relative(root, path);
+  return relativePath.startsWith("..") || isAbsolute(relativePath) ? path : relativePath;
+}
+
+function displayPath(root, path) {
+  const relativePath = relative(root, path);
+  return relativePath.startsWith("..") || isAbsolute(relativePath) ? path : relativePath;
+}
+
+function chunkOutRootDisplay(session, root, chunkIndex) {
+  return displayPath(root, join(session.chunksDir, `chunk-${padChunk(chunkIndex)}`));
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error ?? "Unknown error");
+}
+
+function isNotFoundError(error) {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function padChunk(index) {
+  return String(index).padStart(4, "0");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exitCode = await runDynamicSupervisorLoop({ argv: process.argv.slice(2) });
+}

--- a/scripts/ickb-supervisor-dynamic-loop.mjs
+++ b/scripts/ickb-supervisor-dynamic-loop.mjs
@@ -404,7 +404,7 @@ async function writeOperatorEvent(session, record, dependencies) {
   await appendFileFn(join(session.operatorDir, "events.ndjson"), `${JSON.stringify({
     at: new Date((dependencies.now ?? Date.now)()).toISOString(),
     ...record,
-  })}\n`);
+  }, jsonReplacer)}\n`);
 }
 
 async function appendOperatorStderr(session, text, dependencies) {
@@ -432,7 +432,11 @@ async function sleepMs(ms, dependencies) {
 }
 
 function writeJsonLine(stream, record) {
-  stream.write(`${JSON.stringify({ at: new Date().toISOString(), ...record })}\n`);
+  stream.write(`${JSON.stringify({ at: new Date().toISOString(), ...record }, jsonReplacer)}\n`);
+}
+
+function jsonReplacer(_key, value) {
+  return typeof value === "bigint" ? value.toString() : value;
 }
 
 function minimalProcessEnv(env) {

--- a/scripts/ickb-supervisor-dynamic-loop.mjs
+++ b/scripts/ickb-supervisor-dynamic-loop.mjs
@@ -311,7 +311,7 @@ function runSupervisorChunk(args, choice, root, dependencies, session, chunkInde
   const testerScenarioArgs = choice.scenario === "auto" ? [] : ["--tester-scenario", choice.scenario];
   return runNode([
     args.supervisorLoopScript,
-    "--out-root", childPath(root, chunkOutRoot),
+    "--out-root", displayPath(root, chunkOutRoot),
     "--max-runs", String(args.chunkMaxRuns),
     "--stable-limit", String(args.stableLimit),
     "--backoff-seconds", String(args.chunkBackoffSeconds),
@@ -495,11 +495,6 @@ function checkIgnored(root, relativePath, dependencies) {
   }
   const result = spawnSync("git", ["-C", root, "check-ignore", "--", relativePath], { encoding: "utf8" });
   return result.status === 0;
-}
-
-function childPath(root, path) {
-  const relativePath = relative(root, path);
-  return relativePath.startsWith("..") || isAbsolute(relativePath) ? path : relativePath;
 }
 
 function displayPath(root, path) {

--- a/scripts/ickb-supervisor-dynamic-loop.mjs
+++ b/scripts/ickb-supervisor-dynamic-loop.mjs
@@ -248,6 +248,12 @@ export async function runDynamicSupervisorLoop({ argv, root = rootDir, dependenc
       stderr.write(result.stderr);
       await appendOperatorStderr(session, result.stderr, dependencies);
     }
+    const chunkError = spawnErrorMessage(result);
+    if (chunkError !== undefined) {
+      const message = `Supervisor chunk failed: ${chunkError}\n`;
+      stderr.write(message);
+      await appendOperatorStderr(session, message, dependencies);
+    }
     const stopReason = supervisorLoopStopReason(result.stdout ?? "");
     const finishedRecord = {
       type: "chunk_finished",
@@ -287,8 +293,15 @@ function runTesterPreflight(args, root, dependencies) {
     "--role",
     args.preflightRole,
   ], root, dependencies, { timeout: args.preflightTimeoutSeconds * 1000 });
-  if (result.status !== 0) {
-    return { ok: false, status: result.status, signal: result.signal, stderr: result.stderr, reason: "preflight command failed" };
+  if (result.error !== undefined || result.status !== 0) {
+    const spawnError = spawnErrorMessage(result);
+    return {
+      ok: false,
+      status: result.status,
+      signal: result.signal,
+      stderr: result.stderr,
+      reason: spawnError === undefined ? "preflight command failed" : `preflight command failed: ${spawnError}`,
+    };
   }
   let parsed;
   try {
@@ -421,6 +434,10 @@ function runNode(commandArgs, root, dependencies, options) {
     maxBuffer: 1024 * 1024,
     ...options,
   });
+}
+
+function spawnErrorMessage(result) {
+  return result.error === undefined ? undefined : errorMessage(result.error);
 }
 
 async function sleepMs(ms, dependencies) {

--- a/scripts/ickb-supervisor-dynamic-loop.mjs
+++ b/scripts/ickb-supervisor-dynamic-loop.mjs
@@ -24,6 +24,7 @@ const DEFAULT_CHUNK_TIMEOUT_MARGIN_SECONDS = 60;
 const DEFAULT_PREFLIGHT_TIMEOUT_SECONDS = 120;
 const ALL_CKB_MIN_CKB = 3001n;
 const ICKB_STIMULUS_MIN_CKB = 2100n;
+const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
 
 export function parseArgs(argv) {
   const args = {
@@ -124,6 +125,9 @@ export function parseArgs(argv) {
       throw new Error(`Invalid --chunk-timeout-seconds: expected at least ${minimumChunkTimeoutSeconds.toString()} seconds for this chunk shape`);
     }
   } else {
+    if (minimumChunkTimeoutSeconds > MAX_SAFE_INTEGER) {
+      throw new Error("Invalid derived --chunk-timeout-seconds: expected a safe integer; lower --chunk-max-runs, --child-timeout-seconds, or --chunk-backoff-seconds");
+    }
     args.chunkTimeoutSeconds = Number(minimumChunkTimeoutSeconds);
   }
   return args;
@@ -409,7 +413,7 @@ async function writeLaunchArtifact(session, args, root, dependencies) {
       preflightTimeoutSeconds: args.preflightTimeoutSeconds,
       supervisorArgCount: args.supervisorArgs.length,
     },
-  }, null, 2)}\n`);
+  }, jsonReplacer, 2)}\n`);
 }
 
 async function writeOperatorEvent(session, record, dependencies) {
@@ -457,10 +461,13 @@ function jsonReplacer(_key, value) {
 }
 
 function minimalProcessEnv(env) {
-  return Object.fromEntries(["PATH", "HOME", "LANG", "LC_ALL", "TERM"].flatMap((key) => {
-    const value = env[key];
-    return value === undefined ? [] : [[key, value]];
-  }));
+  return {
+    ...Object.fromEntries(["PATH", "HOME", "LANG", "LC_ALL", "TERM"].flatMap((key) => {
+      const value = env[key];
+      return value === undefined ? [] : [[key, value]];
+    })),
+    NODE_OPTIONS: "--disable-warning=DEP0040",
+  };
 }
 
 function resolveConfiguredPath(root, value, flag) {

--- a/scripts/ickb-supervisor-dynamic-loop.test.mjs
+++ b/scripts/ickb-supervisor-dynamic-loop.test.mjs
@@ -394,6 +394,55 @@ test("dynamic supervisor loop stops on preflight failures", async () => {
   assert.match(output.text, /preflight_failed/u);
 });
 
+test("dynamic supervisor loop reports preflight spawn errors", async () => {
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: ["--log-root", "log", "--session-root", "log/validation/preflight-spawn-error", "--max-chunks", "1"],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: missingStat,
+      lstat: missingStat,
+      mkdir: async () => undefined,
+      writeFile: async () => undefined,
+      appendFile: async () => undefined,
+      spawnSync: () => ({ status: null, signal: null, stdout: "", stderr: "", error: new Error("spawn ETIMEDOUT") }),
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(output.text, /preflight command failed: spawn ETIMEDOUT/u);
+});
+
+test("dynamic supervisor loop preserves supervisor chunk spawn errors", async () => {
+  const appended = new Map();
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: ["--log-root", "log", "--session-root", "log/validation/chunk-spawn-error", "--max-chunks", "1"],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: missingStat,
+      lstat: missingStat,
+      mkdir: async () => undefined,
+      writeFile: async () => undefined,
+      appendFile: async (path, text) => appended.set(path, `${appended.get(path) ?? ""}${text}`),
+      spawnSync: (_command, args) => {
+        if (args[0] === "scripts/ickb-live-preflight.mjs") {
+          return { status: 0, signal: null, stdout: JSON.stringify({ balances: { CKB: { available: "3200" }, ICKB: { available: "0" } } }), stderr: "" };
+        }
+        return { status: null, signal: null, stdout: "", stderr: "", error: new Error("spawn ETIMEDOUT") };
+      },
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(output.text, /Supervisor chunk failed: spawn ETIMEDOUT/u);
+  assert.match(appended.get("/repo/log/validation/chunk-spawn-error/operator/stderr.log"), /Supervisor chunk failed: spawn ETIMEDOUT/u);
+});
+
 test("dynamic supervisor loop preserves malformed preflight stderr", async () => {
   const appended = new Map();
   const output = { text: "", write(chunk) { this.text += chunk; } };

--- a/scripts/ickb-supervisor-dynamic-loop.test.mjs
+++ b/scripts/ickb-supervisor-dynamic-loop.test.mjs
@@ -1,0 +1,424 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  chooseTesterScenario,
+  DEFAULT_CHILD_TIMEOUT_SECONDS_VALUE as DEFAULT_SUPERVISOR_LOOP_CHILD_TIMEOUT_SECONDS,
+  fixed8DecimalToUnits,
+  parseArgs,
+  runDynamicSupervisorLoop,
+  usage,
+} from "./ickb-supervisor-dynamic-loop.mjs";
+
+test("dynamic supervisor loop parses options", () => {
+  assert.equal(parseArgs(["--help"]).help, true);
+  assert.deepEqual(parseArgs([
+    "--tester-config", "config/custom.json",
+    "--preflight-role", "tester-watch",
+    "--log-root", "log/custom",
+    "--session-root", "log/custom/validation/manual-session",
+    "--max-chunks", "2",
+    "--chunk-max-runs", "3",
+    "--stable-limit", "99",
+    "--chunk-backoff-seconds", "4",
+    "--between-chunks-seconds", "5",
+    "--child-timeout-seconds", "6",
+    "--command-timeout-seconds", "7",
+    "--chunk-timeout-seconds", "90",
+    "--preflight-timeout-seconds", "9",
+    "--preflight-script", "scripts/preflight.mjs",
+    "--supervisor-loop-script", "scripts/loop.mjs",
+  ]), {
+    help: false,
+    testerConfig: "config/custom.json",
+    preflightRole: "tester-watch",
+    logRoot: "log/custom",
+    sessionRoot: "log/custom/validation/manual-session",
+    maxChunks: 2,
+    chunkMaxRuns: 3,
+    stableLimit: 99,
+    chunkBackoffSeconds: 4,
+    betweenChunksSeconds: 5,
+    childTimeoutSeconds: 6,
+    commandTimeoutSeconds: 7,
+    chunkTimeoutSeconds: 90,
+    preflightTimeoutSeconds: 9,
+    preflightScript: "scripts/preflight.mjs",
+    supervisorLoopScript: "scripts/loop.mjs",
+    supervisorArgs: [],
+  });
+  assert.deepEqual(parseArgs(["--", "--target-outcome", "bot_match_committed"]).supervisorArgs, [
+    "--target-outcome",
+    "bot_match_committed",
+  ]);
+  assert.equal(parseArgs([]).childTimeoutSeconds, DEFAULT_SUPERVISOR_LOOP_CHILD_TIMEOUT_SECONDS);
+  assert.equal(
+    parseArgs(["--chunk-max-runs", "3", "--child-timeout-seconds", "6", "--chunk-backoff-seconds", "4"]).chunkTimeoutSeconds,
+    86,
+  );
+  assert.throws(() => parseArgs(["--max-chunks", "0"]), /Invalid --max-chunks/u);
+  assert.throws(
+    () => parseArgs(["--chunk-max-runs", "3", "--child-timeout-seconds", "6", "--chunk-backoff-seconds", "4", "--chunk-timeout-seconds", "85"]),
+    /Invalid --chunk-timeout-seconds/u,
+  );
+  assert.throws(() => parseArgs(["--unknown"]), /Unknown argument/u);
+  assert.throws(() => parseArgs(["--", "--out-dir", "log/validation/bad"]), /Do not pass supervisor --out-dir/u);
+  assert.match(usage(), /tester-config/u);
+  assert.match(usage(), /--log-root/u);
+});
+
+test("dynamic supervisor loop creates a default validation session root", async () => {
+  const originalPrivateKey = process.env.PRIVATE_KEY;
+  process.env.PRIVATE_KEY = "operator-secret";
+  const writes = new Map();
+  const appended = new Map();
+  const commands = [];
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  try {
+    const exitCode = await runDynamicSupervisorLoop({
+      root: "/repo",
+      argv: ["--max-chunks", "1"],
+      io: { stdout: output, stderr: output },
+      dependencies: {
+        now: () => 1700000000123,
+        pid: 4321,
+        checkIgnored: (path) => path.startsWith("log/"),
+        stat: missingStat,
+        lstat: missingStat,
+        mkdir: async () => undefined,
+        writeFile: async (path, text) => writes.set(path, text),
+        appendFile: async (path, text) => appended.set(path, (appended.get(path) ?? "") + text),
+        spawnSync: (_command, args, options) => {
+          commands.push({ args, options });
+          if (args[0] === "scripts/ickb-live-preflight.mjs") {
+            return { status: 0, signal: null, stdout: JSON.stringify({ balances: { CKB: { available: "3200" }, ICKB: { available: "0" } } }), stderr: "" };
+          }
+          return { status: 0, signal: null, stdout: "loop stopped reason=max_runs runs=1 out=log/validation/dynamic-1700000000-4321/chunks/chunk-0001\n", stderr: "" };
+        },
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(writes.has("/repo/log/validation/dynamic-1700000000-4321/operator/launch.json"), true);
+    assert.equal(appended.has("/repo/log/validation/dynamic-1700000000-4321/operator/events.ndjson"), true);
+    assert.deepEqual(commands[1].args.slice(0, 3), [
+      "scripts/ickb-supervisor-loop.mjs",
+      "--out-root",
+      "log/validation/dynamic-1700000000-4321/chunks/chunk-0001",
+    ]);
+    assert.equal(commands[0].options.env.PRIVATE_KEY, undefined);
+    assert.equal(commands[1].options.env.PRIVATE_KEY, undefined);
+    assert.match(output.text, /"type":"chunk_finished"/u);
+    assert.match(output.text, /log\/validation\/dynamic-1700000000-4321\/chunks\/chunk-0001/u);
+  } finally {
+    if (originalPrivateKey === undefined) {
+      delete process.env.PRIVATE_KEY;
+    } else {
+      process.env.PRIVATE_KEY = originalPrivateKey;
+    }
+  }
+});
+
+test("dynamic supervisor loop validates explicit session roots", async () => {
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+
+  const outsideExit = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: ["--log-root", "log", "--session-root", "other/session", "--max-chunks", "1"],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      spawnSync: () => {
+        throw new Error("should not spawn with invalid session root");
+      },
+    },
+  });
+  assert.equal(outsideExit, 1);
+  assert.match(output.text, /--session-root must stay under --log-root/u);
+
+  output.text = "";
+  const badShapeExit = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: ["--log-root", "log", "--session-root", "log/manual-session", "--max-chunks", "1"],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      spawnSync: () => {
+        throw new Error("should not spawn with invalid session root shape");
+      },
+    },
+  });
+  assert.equal(badShapeExit, 1);
+  assert.match(output.text, /--session-root must be <log-root>\/validation\/<session>/u);
+
+  output.text = "";
+  const reusedExit = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: ["--log-root", "log", "--session-root", "log/validation/existing", "--max-chunks", "1"],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: async () => ({}),
+      spawnSync: () => {
+        throw new Error("should not spawn with reused session root");
+      },
+    },
+  });
+  assert.equal(reusedExit, 1);
+  assert.match(output.text, /Validation session root already exists: log\/validation\/existing/u);
+});
+
+test("dynamic supervisor loop refuses symlinked session roots", async () => {
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: ["--log-root", "log", "--session-root", "log/validation/symlinked", "--max-chunks", "1"],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: missingStat,
+      lstat: async (path) => ({ isSymbolicLink: () => path === "/repo/log/validation" }),
+      spawnSync: () => {
+        throw new Error("should not spawn through symlinked session root");
+      },
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(output.text, /Refusing to use session root through symlinked path: \/repo\/log\/validation/u);
+});
+
+test("dynamic supervisor loop chooses fundable tester scenarios", () => {
+  const ckb = 100000000n;
+  assert.equal(fixed8DecimalToUnits("1.00000001"), ckb + 1n);
+  assert.equal(fixed8DecimalToUnits("bad"), undefined);
+  assert.deepEqual(chooseTesterScenario({ ckb: 3001n * ckb, ickb: 0n }), {
+    scenario: "all-ckb-limit-order",
+    feeArgs: [],
+  });
+  assert.deepEqual(chooseTesterScenario({ ckb: 2100n * ckb, ickb: 1n }), {
+    scenario: "ickb-to-ckb-limit-order",
+    feeArgs: ["--tester-fee", "1", "--tester-fee-base", "1000"],
+  });
+  assert.deepEqual(chooseTesterScenario({ ckb: 2099n * ckb, ickb: 1n }), {
+    scenario: "auto",
+    feeArgs: [],
+  });
+});
+
+test("dynamic supervisor loop runs selected bounded chunks", async () => {
+  const commands = [];
+  const sleeps = [];
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: [
+      "--log-root", "log",
+      "--session-root", "log/validation/test-session",
+      "--max-chunks", "2",
+      "--between-chunks-seconds", "0",
+      "--",
+      "--target-outcome", "bot_match_committed",
+    ],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: missingStat,
+      lstat: missingStat,
+      mkdir: async () => undefined,
+      writeFile: async () => undefined,
+      appendFile: async () => undefined,
+      spawnSync: (_command, args, options) => {
+        commands.push({ args, options });
+        if (args[0] === "scripts/ickb-live-preflight.mjs") {
+          const stdout = commands.length === 1
+            ? JSON.stringify({ balances: { CKB: { available: "3200" }, ICKB: { available: "0" } } })
+            : JSON.stringify({ balances: { CKB: { available: "2100" }, ICKB: { available: "1" } } });
+          return { status: 0, signal: null, stdout, stderr: "" };
+        }
+        return { status: 0, signal: null, stdout: "loop run=1 status=0 stopped=max_cycles outcomes=- tx=0 new=- stable=1 state=- decision=max_runs out=logs/live-supervisor/test\n", stderr: "" };
+      },
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(sleeps.length, 0);
+  assert.equal(commands.length, 4);
+  assert.equal(commands[1].args.includes("all-ckb-limit-order"), true);
+  assert.equal(commands[3].args.includes("ickb-to-ckb-limit-order"), true);
+  assert.deepEqual(commands[1].args.slice(0, 3), ["scripts/ickb-supervisor-loop.mjs", "--out-root", "log/validation/test-session/chunks/chunk-0001"]);
+  const separator = commands[1].args.indexOf("--");
+  assert.equal(commands[1].args.slice(0, separator).includes("--out-root"), true);
+  assert.equal(commands[1].args.slice(separator + 1).includes("--target-outcome"), true);
+  assert.deepEqual(commands[3].args.slice(-4), ["--tester-fee", "1", "--tester-fee-base", "1000"]);
+  assert.match(output.text, /"type":"selected"/u);
+  assert.match(output.text, /testerScenario":"all-ckb-limit-order"/u);
+  assert.match(output.text, /testerScenario":"ickb-to-ckb-limit-order"/u);
+});
+
+test("dynamic supervisor loop stops after inspection-worthy supervisor-loop reasons", async () => {
+  const commands = [];
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: [
+      "--log-root", "log",
+      "--session-root", "log/validation/inspection-session",
+      "--max-chunks", "3",
+      "--between-chunks-seconds", "0",
+    ],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: missingStat,
+      lstat: missingStat,
+      mkdir: async () => undefined,
+      writeFile: async () => undefined,
+      appendFile: async () => undefined,
+      spawnSync: (_command, args, options) => {
+        commands.push({ args, options });
+        if (args[0] === "scripts/ickb-live-preflight.mjs") {
+          return { status: 0, signal: null, stdout: JSON.stringify({ balances: { CKB: { available: "3200" }, ICKB: { available: "0" } } }), stderr: "" };
+        }
+        return { status: 0, signal: null, stdout: "loop run=1 status=0 stopped=max_cycles outcomes=tester_order_created tx=1 new=tester_order_created stable=1 state=- decision=tx_observed out=log/validation/inspection-session/chunks/chunk-0001\nloop stopped reason=tx_observed runs=1 out=log/validation/inspection-session/chunks/chunk-0001\n", stderr: "" };
+      },
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(commands.length, 2);
+  assert.match(output.text, /"supervisorLoopStopReason":"tx_observed"/u);
+});
+
+test("dynamic supervisor loop leaves supervisor target steering intact for auto tester choice", async () => {
+  const commands = [];
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: [
+      "--log-root", "log",
+      "--session-root", "log/validation/auto-session",
+      "--max-chunks", "1",
+      "--",
+      "--target-outcome", "tester_conversion_created",
+    ],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: missingStat,
+      lstat: missingStat,
+      mkdir: async () => undefined,
+      writeFile: async () => undefined,
+      appendFile: async () => undefined,
+      spawnSync: (_command, args, options) => {
+        commands.push({ args, options });
+        if (args[0] === "scripts/ickb-live-preflight.mjs") {
+          return { status: 0, signal: null, stdout: JSON.stringify({ balances: { CKB: { available: "1000" }, ICKB: { available: "0" } } }), stderr: "" };
+        }
+        return { status: 0, signal: null, stdout: "loop run=1 status=0 stopped=max_cycles outcomes=- tx=0 new=- stable=1 state=- decision=max_runs out=logs/live-supervisor/test\n", stderr: "" };
+      },
+    },
+  });
+
+  const supervisorArgs = commands[1].args;
+  const separator = supervisorArgs.indexOf("--");
+  const passthrough = supervisorArgs.slice(separator + 1);
+  assert.equal(exitCode, 0);
+  assert.equal(passthrough.includes("--tester-scenario"), false);
+  assert.equal(passthrough.includes("auto"), false);
+  assert.equal(passthrough.includes("--target-outcome"), true);
+  assert.match(output.text, /testerScenario":"auto"/u);
+});
+
+test("dynamic supervisor loop leaves fresh-order skip target planning to supervisor", async () => {
+  const commands = [];
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: [
+      "--log-root", "log",
+      "--session-root", "log/validation/fresh-skip-session",
+      "--max-chunks", "1",
+      "--",
+      "--target-outcome", "tester_fresh_order_skip",
+    ],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: missingStat,
+      lstat: missingStat,
+      mkdir: async () => undefined,
+      writeFile: async () => undefined,
+      appendFile: async () => undefined,
+      spawnSync: (_command, args, options) => {
+        commands.push({ args, options });
+        if (args[0] === "scripts/ickb-live-preflight.mjs") {
+          return { status: 0, signal: null, stdout: JSON.stringify({ balances: { CKB: { available: "2100" }, ICKB: { available: "1" } } }), stderr: "" };
+        }
+        return { status: 0, signal: null, stdout: "loop run=1 status=0 stopped=max_cycles outcomes=tester_fresh_order_skip tx=0 new=- stable=1 state=- decision=max_runs out=logs/live-supervisor/test\n", stderr: "" };
+      },
+    },
+  });
+
+  const supervisorArgs = commands[1].args;
+  const separator = supervisorArgs.indexOf("--");
+  const passthrough = supervisorArgs.slice(separator + 1);
+  assert.equal(exitCode, 0);
+  assert.equal(passthrough.includes("--scenario"), false);
+  assert.equal(passthrough.includes("--tester-scenario"), true);
+  assert.equal(passthrough.includes("ickb-to-ckb-limit-order"), true);
+  assert.equal(passthrough.includes("--tester-fee"), true);
+  assert.equal(passthrough.includes("--target-outcome"), true);
+});
+
+test("dynamic supervisor loop stops on preflight failures", async () => {
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: ["--log-root", "log", "--session-root", "log/validation/preflight-failure", "--max-chunks", "1"],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: missingStat,
+      lstat: missingStat,
+      mkdir: async () => undefined,
+      writeFile: async () => undefined,
+      appendFile: async () => undefined,
+      spawnSync: () => ({ status: 2, signal: null, stdout: "", stderr: "" }),
+    },
+  });
+
+  assert.equal(exitCode, 2);
+  assert.match(output.text, /preflight_failed/u);
+});
+
+test("dynamic supervisor loop preserves malformed preflight stderr", async () => {
+  const appended = new Map();
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runDynamicSupervisorLoop({
+    root: "/repo",
+    argv: ["--log-root", "log", "--session-root", "log/validation/preflight-stderr", "--max-chunks", "1"],
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      checkIgnored: () => true,
+      stat: missingStat,
+      lstat: missingStat,
+      mkdir: async () => undefined,
+      writeFile: async () => undefined,
+      appendFile: async (path, text) => appended.set(path, `${appended.get(path) ?? ""}${text}`),
+      spawnSync: () => ({ status: 0, signal: null, stdout: "not json", stderr: "preflight diagnostic\n" }),
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(output.text, /preflight diagnostic/u);
+  assert.match(appended.get("/repo/log/validation/preflight-stderr/operator/stderr.log"), /preflight diagnostic/u);
+});
+
+function missingStat() {
+  const error = new Error("missing");
+  error.code = "ENOENT";
+  throw error;
+}

--- a/scripts/ickb-supervisor-dynamic-loop.test.mjs
+++ b/scripts/ickb-supervisor-dynamic-loop.test.mjs
@@ -55,6 +55,10 @@ test("dynamic supervisor loop parses options", () => {
     parseArgs(["--chunk-max-runs", "3", "--child-timeout-seconds", "6", "--chunk-backoff-seconds", "4"]).chunkTimeoutSeconds,
     86,
   );
+  assert.throws(
+    () => parseArgs(["--chunk-max-runs", String(Number.MAX_SAFE_INTEGER), "--child-timeout-seconds", String(Number.MAX_SAFE_INTEGER)]),
+    /Invalid derived --chunk-timeout-seconds: expected a safe integer/u,
+  );
   assert.throws(() => parseArgs(["--max-chunks", "0"]), /Invalid --max-chunks/u);
   assert.throws(
     () => parseArgs(["--chunk-max-runs", "3", "--child-timeout-seconds", "6", "--chunk-backoff-seconds", "4", "--chunk-timeout-seconds", "85"]),
@@ -105,6 +109,8 @@ test("dynamic supervisor loop creates a default validation session root", async 
       "--out-root",
       "log/validation/dynamic-1700000000-4321/chunks/chunk-0001",
     ]);
+    assert.equal(commands[0].options.env.NODE_OPTIONS, "--disable-warning=DEP0040");
+    assert.equal(commands[1].options.env.NODE_OPTIONS, "--disable-warning=DEP0040");
     assert.equal(commands[0].options.env.PRIVATE_KEY, undefined);
     assert.equal(commands[1].options.env.PRIVATE_KEY, undefined);
     assert.match(output.text, /"type":"chunk_finished"/u);

--- a/scripts/ickb-supervisor-loop.mjs
+++ b/scripts/ickb-supervisor-loop.mjs
@@ -1,36 +1,28 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { lstat, readFile } from "node:fs/promises";
+import { isAbsolute, join, parse, relative, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { TX_CREATING_OUTCOMES } from "../apps/supervisor/dist/index.js";
+import { parseNonNegativeInteger, parsePositiveInteger, valueAfter } from "./ickb-script-helpers.mjs";
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const DEFAULT_MAX_RUNS = 10;
 const DEFAULT_STABLE_LIMIT = 3;
 const DEFAULT_BACKOFF_SECONDS = 30;
+const DEFAULT_CHILD_TIMEOUT_SECONDS = 65 * 60;
+export const DEFAULT_CHILD_TIMEOUT_SECONDS_VALUE = DEFAULT_CHILD_TIMEOUT_SECONDS;
 const DEFAULT_SUPERVISOR_SCRIPT = "apps/supervisor/dist/index.js";
 const SUPERVISOR_OUTPUT_ROOT = "logs/live-supervisor";
 export function parseArgs(argv) {
-  if (argv.length === 2 && argv[0] === "--" && (argv[1] === "-h" || argv[1] === "--help")) {
-    return {
-      help: true,
-      maxRuns: DEFAULT_MAX_RUNS,
-      stableLimit: DEFAULT_STABLE_LIMIT,
-      backoffSeconds: DEFAULT_BACKOFF_SECONDS,
-      supervisorScript: DEFAULT_SUPERVISOR_SCRIPT,
-      supervisorArgs: [],
-    };
-  }
   const args = {
     help: false,
     maxRuns: DEFAULT_MAX_RUNS,
     stableLimit: DEFAULT_STABLE_LIMIT,
     backoffSeconds: DEFAULT_BACKOFF_SECONDS,
+    childTimeoutSeconds: DEFAULT_CHILD_TIMEOUT_SECONDS,
     supervisorScript: DEFAULT_SUPERVISOR_SCRIPT,
     supervisorArgs: [],
   };
-  let parsedLoopOption = false;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--") {
@@ -43,32 +35,27 @@ export function parseArgs(argv) {
     }
     if (arg === "--out-root") {
       args.outRoot = valueAfter(argv, ++index, arg);
-      parsedLoopOption = true;
       continue;
     }
     if (arg === "--max-runs") {
       args.maxRuns = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
-      parsedLoopOption = true;
       continue;
     }
     if (arg === "--stable-limit") {
       args.stableLimit = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
-      parsedLoopOption = true;
       continue;
     }
     if (arg === "--backoff-seconds") {
       args.backoffSeconds = parseNonNegativeInteger(valueAfter(argv, ++index, arg), arg);
-      parsedLoopOption = true;
+      continue;
+    }
+    if (arg === "--child-timeout-seconds") {
+      args.childTimeoutSeconds = parsePositiveInteger(valueAfter(argv, ++index, arg), arg);
       continue;
     }
     if (arg === "--supervisor-script") {
       args.supervisorScript = valueAfter(argv, ++index, arg);
-      parsedLoopOption = true;
       continue;
-    }
-    if (!parsedLoopOption) {
-      args.supervisorArgs = argv.slice(index);
-      break;
     }
     throw new Error(`Unknown argument before --: ${arg}`);
   }
@@ -82,10 +69,11 @@ export function usage() {
   return [
     "Usage: node scripts/ickb-supervisor-loop.mjs [loop-options] -- [supervisor-options]",
     "Loop options:",
-    `  --out-root <ignored-dir>       Default: ${SUPERVISOR_OUTPUT_ROOT}/loop-<time>-<pid>`,
+    `  --out-root <dir>               Default: ${SUPERVISOR_OUTPUT_ROOT}/loop-<time>-<pid>`,
     `  --max-runs <n>                 Default: ${String(DEFAULT_MAX_RUNS)}`,
     `  --stable-limit <n>             Default: ${String(DEFAULT_STABLE_LIMIT)}`,
     `  --backoff-seconds <n>          Default: ${String(DEFAULT_BACKOFF_SECONDS)}`,
+    `  --child-timeout-seconds <n>    Default: ${String(DEFAULT_CHILD_TIMEOUT_SECONDS)}`,
     `  --supervisor-script <path>     Default: ${DEFAULT_SUPERVISOR_SCRIPT}`,
     "  -h, --help",
     "Reads only each child run summary.json.",
@@ -95,8 +83,9 @@ export function usage() {
 
 export function summarizeRun(summary, { runIndex, relativeOutDir, status }) {
   const aggregateCounts = countRecord(summary.aggregateCounts);
-  const txHashesByOutcome = arrayRecord(summary.txHashesByOutcome);
-  const txCount = txCreatingCount(txHashesByOutcome);
+  const txCount = requiredCount(summary.txCreatingTxHashCount, "txCreatingTxHashCount");
+  const txCreatingOutcomeCount = requiredCount(summary.txCreatingOutcomeCount, "txCreatingOutcomeCount");
+  const hasTxCreatingOutcome = txCreatingOutcomeCount > 0;
   const artifacts = stringArray(summary.artifacts);
   return {
     runIndex,
@@ -106,6 +95,7 @@ export function summarizeRun(summary, { runIndex, relativeOutDir, status }) {
     aggregateCounts,
     outcomes: Object.keys(aggregateCounts).filter((key) => aggregateCounts[key] > 0).sort(),
     txCount,
+    hasTxCreatingOutcome,
     hasIncident: artifacts.some((artifact) => artifact.endsWith("incident.json")),
     skipReasons: stringArray(summary.skipReasons),
     publicState: isRecord(summary.publicVsOwnedStateAssumptions) ? summary.publicVsOwnedStateAssumptions : null,
@@ -122,17 +112,17 @@ export function decideNext({ run, priorOutcomes, previousSignature, stableCount,
   if (run.status !== 0) {
     return { action: "stop", reason: "supervisor_nonzero", newOutcomes, stableCount: nextStableCount, exitCode: run.status };
   }
-  if (run.txCount > 0) {
+  if (run.txCount > 0 || run.hasTxCreatingOutcome) {
     return { action: "stop", reason: "tx_observed", newOutcomes, stableCount: nextStableCount, exitCode: 0 };
   }
   if (runIndex > 1 && newOutcomes.length > 0) {
     return { action: "stop", reason: "new_outcome", newOutcomes, stableCount: nextStableCount, exitCode: 0 };
   }
-  if (nextStableCount >= stableLimit) {
-    return { action: "stop", reason: "stable_no_progress", newOutcomes, stableCount: nextStableCount, exitCode: 0 };
-  }
   if (runIndex >= maxRuns) {
     return { action: "stop", reason: "max_runs", newOutcomes, stableCount: nextStableCount, exitCode: 0 };
+  }
+  if (nextStableCount >= stableLimit) {
+    return { action: "stop", reason: "stable_no_progress", newOutcomes, stableCount: nextStableCount, exitCode: 0 };
   }
   return { action: "continue", reason: "continue", newOutcomes, stableCount: nextStableCount, exitCode: 0 };
 }
@@ -142,6 +132,10 @@ export function summarySignature(summary) {
     stopped: typeof summary.stopped === "string" ? summary.stopped : "unknown",
     aggregateCounts: sortedEntries(countRecord(summary.aggregateCounts)),
     skipReasons: stringArray(summary.skipReasons).sort(),
+    testerOrderEvidence: normalizeJson(summary.testerOrderEvidence ?? null),
+    preflightState: normalizeJson(summary.preflightState ?? null),
+    scenarioAttempts: normalizeJson(summary.scenarioAttempts ?? null),
+    coverage: normalizeJson(summary.coverage ?? null),
     publicVsOwnedStateAssumptions: normalizeJson(summary.publicVsOwnedStateAssumptions ?? null),
   });
 }
@@ -169,6 +163,7 @@ export async function runSupervisorLoop({ argv, root = rootDir, dependencies = {
     supervisorScript = isAbsolute(args.supervisorScript)
       ? args.supervisorScript
       : resolve(root, args.supervisorScript);
+    await assertNoSymlinkedLoopOutputAncestors(root, outRoot.absolutePath, dependencies);
   } catch (error) {
     stderr.write(`${errorMessage(error)}\n${usage()}\n`);
     return 1;
@@ -179,12 +174,13 @@ export async function runSupervisorLoop({ argv, root = rootDir, dependencies = {
 
   for (let runIndex = 1; runIndex <= args.maxRuns; runIndex += 1) {
     const runOutDir = join(outRoot.absolutePath, `run-${padRun(runIndex)}`);
-    const relativeOutDir = relative(root, runOutDir);
+    const relativeOutDir = displayPath(root, runOutDir);
     const spawnResult = spawnSupervisor({
       root,
       supervisorScript,
       supervisorArgs: args.supervisorArgs,
       relativeOutDir,
+      childTimeoutSeconds: args.childTimeoutSeconds,
       dependencies,
     });
     const status = typeof spawnResult.status === "number" ? spawnResult.status : 1;
@@ -226,7 +222,7 @@ export async function runSupervisorLoop({ argv, root = rootDir, dependencies = {
   return 0;
 }
 
-function spawnSupervisor({ root, supervisorScript, supervisorArgs, relativeOutDir, dependencies }) {
+function spawnSupervisor({ root, supervisorScript, supervisorArgs, relativeOutDir, childTimeoutSeconds, dependencies }) {
   const spawnSyncFn = dependencies.spawnSync ?? spawnSync;
   return spawnSyncFn(process.execPath, [
     supervisorScript,
@@ -235,7 +231,10 @@ function spawnSupervisor({ root, supervisorScript, supervisorArgs, relativeOutDi
     relativeOutDir,
   ], {
     cwd: root,
+    env: minimalProcessEnv(process.env),
     stdio: "ignore",
+    timeout: childTimeoutSeconds * 1000,
+    killSignal: "SIGTERM",
   });
 }
 
@@ -305,19 +304,39 @@ function formatPublicState(state) {
   return fields.length === 0 ? "-" : fields.join(",");
 }
 
+function minimalProcessEnv(env) {
+  return Object.fromEntries(["PATH", "HOME", "LANG", "LC_ALL", "TERM"].flatMap((key) => {
+    const value = env[key];
+    return value === undefined ? [] : [[key, value]];
+  }));
+}
+
 function resolveLoopOutRoot(root, outRoot) {
   if (outRoot === "") {
     throw new Error("--out-root must not be empty");
   }
   const absolutePath = isAbsolute(outRoot) ? outRoot : resolve(root, outRoot);
-  const relativePath = relative(root, absolutePath);
-  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
-    throw new Error("--out-root must stay inside the repo");
-  }
-  if (relativePath !== SUPERVISOR_OUTPUT_ROOT && !relativePath.startsWith(`${SUPERVISOR_OUTPUT_ROOT}/`)) {
-    throw new Error(`--out-root must be under ${SUPERVISOR_OUTPUT_ROOT}`);
+  const relativePath = displayPath(root, absolutePath);
+  if (!isAllowedLoopOutRoot(absolutePath, relativePath)) {
+    throw new Error(`--out-root must be under ${SUPERVISOR_OUTPUT_ROOT} or a validation session chunks directory`);
   }
   return { absolutePath, relativePath };
+}
+
+function isAllowedLoopOutRoot(absolutePath, relativePath) {
+  return relativePath === SUPERVISOR_OUTPUT_ROOT ||
+    relativePath.startsWith(`${SUPERVISOR_OUTPUT_ROOT}/`) ||
+    isValidationChunkRoot(absolutePath);
+}
+
+function isValidationChunkRoot(path) {
+  const parts = path.split(/[\\/]+/u);
+  for (let index = 0; index < parts.length - 3; index += 1) {
+    if (parts[index] === "validation" && parts[index + 2] === "chunks" && /^chunk-[0-9]{4}$/u.test(parts[index + 3] ?? "") && index + 4 === parts.length) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function defaultOutRoot(nowMs, pid) {
@@ -337,28 +356,45 @@ function countRecord(value) {
   return counts;
 }
 
-function arrayRecord(value) {
-  if (!isRecord(value)) {
-    return {};
-  }
-  const arrays = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (Array.isArray(item)) {
-      arrays[key] = item.filter((entry) => typeof entry === "string");
-    }
-  }
-  return arrays;
-}
-
-function txCreatingCount(txHashesByOutcome) {
-  return Object.entries(txHashesByOutcome).reduce(
-    (sum, [outcome, hashes]) => sum + (TX_CREATING_OUTCOMES.has(outcome) ? hashes.length : 0),
-    0,
-  );
-}
-
 function sortedEntries(record) {
   return Object.entries(record).sort(([left], [right]) => left.localeCompare(right));
+}
+
+async function assertNoSymlinkedLoopOutputAncestors(root, absolutePath, dependencies) {
+  const lstatFn = dependencies.lstat ?? lstat;
+  const base = isInside(root, absolutePath) ? root : parse(absolutePath).root;
+  const parts = relative(base, absolutePath).split(sep).filter((part) => part !== "");
+  let current = base;
+  for (const part of parts) {
+    current = join(current, part);
+    try {
+      const stats = await lstatFn(current);
+      if (stats.isSymbolicLink()) {
+        throw new Error(`Refusing to use loop output root through symlinked path: ${displayPath(root, current)}`);
+      }
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
+function isInside(root, path) {
+  const relationship = relative(root, path);
+  return relationship === "" || (!relationship.startsWith("..") && !isAbsolute(relationship));
+}
+
+function displayPath(root, path) {
+  return isInside(root, path) ? relative(root, path) : path;
+}
+
+function requiredCount(value, key) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`summary.json ${key} missing or invalid`);
+  }
+  return value;
 }
 
 function normalizeJson(value) {
@@ -383,38 +419,12 @@ function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isNotFoundError(error) {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
 function shellWord(value) {
   return String(value).replace(/\s+/gu, "_");
-}
-
-function valueAfter(argv, index, flag) {
-  const value = argv[index];
-  if (value === undefined || value.startsWith("--")) {
-    throw new Error(`Missing value for ${flag}`);
-  }
-  return value;
-}
-
-function parsePositiveInteger(value, flag) {
-  if (!/^[1-9][0-9]*$/u.test(value)) {
-    throw new Error(`Invalid ${flag}: expected a positive integer`);
-  }
-  const parsed = BigInt(value);
-  if (parsed > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new Error(`Invalid ${flag}: expected a safe integer`);
-  }
-  return Number(parsed);
-}
-
-function parseNonNegativeInteger(value, flag) {
-  if (!/^(0|[1-9][0-9]*)$/u.test(value)) {
-    throw new Error(`Invalid ${flag}: expected a non-negative integer`);
-  }
-  const parsed = BigInt(value);
-  if (parsed > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new Error(`Invalid ${flag}: expected a safe integer`);
-  }
-  return Number(parsed);
 }
 
 function padRun(index) {

--- a/scripts/ickb-supervisor-loop.mjs
+++ b/scripts/ickb-supervisor-loop.mjs
@@ -305,10 +305,13 @@ function formatPublicState(state) {
 }
 
 function minimalProcessEnv(env) {
-  return Object.fromEntries(["PATH", "HOME", "LANG", "LC_ALL", "TERM"].flatMap((key) => {
-    const value = env[key];
-    return value === undefined ? [] : [[key, value]];
-  }));
+  return {
+    ...Object.fromEntries(["PATH", "HOME", "LANG", "LC_ALL", "TERM"].flatMap((key) => {
+      const value = env[key];
+      return value === undefined ? [] : [[key, value]];
+    })),
+    NODE_OPTIONS: "--disable-warning=DEP0040",
+  };
 }
 
 function resolveLoopOutRoot(root, outRoot) {

--- a/scripts/ickb-supervisor-loop.test.mjs
+++ b/scripts/ickb-supervisor-loop.test.mjs
@@ -248,6 +248,7 @@ test("supervisor loop runs bounded supervisor commands until stable", async () =
     assert.equal(commands.length, 2);
     assert.deepEqual(commands[0].args.slice(-4), ["--scenario", "bot-only", "--out-dir", "logs/live-supervisor/loop-test/run-0001"]);
     assert.equal(commands[0].options.timeout, DEFAULT_CHILD_TIMEOUT_SECONDS_VALUE * 1000);
+    assert.equal(commands[0].options.env.NODE_OPTIONS, "--disable-warning=DEP0040");
     assert.equal(commands[0].options.env.PRIVATE_KEY, undefined);
     assert.match(output.text, /decision=continue/u);
     assert.match(output.text, /loop stopped reason=stable_no_progress runs=2/u);

--- a/scripts/ickb-supervisor-loop.test.mjs
+++ b/scripts/ickb-supervisor-loop.test.mjs
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import test from "node:test";
 import {
   decideNext,
+  DEFAULT_CHILD_TIMEOUT_SECONDS_VALUE,
   parseArgs,
   runSupervisorLoop,
   summarizeRun,
@@ -11,12 +12,13 @@ import {
 } from "./ickb-supervisor-loop.mjs";
 
 test("supervisor loop parses loop options and supervisor passthrough", () => {
-  assert.equal(parseArgs(["--", "--help"]).help, true);
+  assert.deepEqual(parseArgs(["--", "--help"]).supervisorArgs, ["--help"]);
   assert.deepEqual(parseArgs([
     "--out-root", "logs/live-supervisor/loop-test",
     "--max-runs", "5",
     "--stable-limit", "2",
     "--backoff-seconds", "0",
+    "--child-timeout-seconds", "120",
     "--supervisor-script", "apps/supervisor/dist/custom.js",
     "--",
     "--scenario", "bot-only",
@@ -26,29 +28,27 @@ test("supervisor loop parses loop options and supervisor passthrough", () => {
     maxRuns: 5,
     stableLimit: 2,
     backoffSeconds: 0,
+    childTimeoutSeconds: 120,
     supervisorScript: "apps/supervisor/dist/custom.js",
     supervisorArgs: ["--scenario", "bot-only"],
   });
-  assert.deepEqual(parseArgs([
-    "--scenario", "standard-cycle",
-    "--max-cycles", "1",
-  ]), {
-    help: false,
-    maxRuns: 10,
-    stableLimit: 3,
-    backoffSeconds: 30,
-    supervisorScript: "apps/supervisor/dist/index.js",
-    supervisorArgs: ["--scenario", "standard-cycle", "--max-cycles", "1"],
-  });
+  assert.throws(() => parseArgs(["--scenario", "standard-cycle"]), /Unknown argument before --: --scenario/u);
+  assert.deepEqual(parseArgs(["--max-runs", "1", "--", "--scenario", "standard-cycle"]).supervisorArgs, [
+    "--scenario",
+    "standard-cycle",
+  ]);
   assert.throws(() => parseArgs(["--max-runs", "0"]), /Invalid --max-runs/u);
   assert.equal(parseArgs(["--max-runs", String(Number.MAX_SAFE_INTEGER)]).maxRuns, Number.MAX_SAFE_INTEGER);
   assert.throws(() => parseArgs(["--max-runs", "9007199254740992"]), /Invalid --max-runs: expected a safe integer/u);
   assert.throws(() => parseArgs(["--stable-limit", "9007199254740992"]), /Invalid --stable-limit: expected a safe integer/u);
   assert.throws(() => parseArgs(["--backoff-seconds", "9007199254740993"]), /Invalid --backoff-seconds: expected a safe integer/u);
+  assert.throws(() => parseArgs(["--child-timeout-seconds", "0"]), /Invalid --child-timeout-seconds/u);
   assert.throws(() => parseArgs(["--", "--out-dir", "logs/live-supervisor/x"]), /Do not pass supervisor --out-dir/u);
   assert.throws(() => parseArgs(["--", "--out-dir=logs/live-supervisor/x"]), /Do not pass supervisor --out-dir/u);
-  assert.throws(() => parseArgs(["--scenario", "standard-cycle", "--out-dir=logs/live-supervisor/x"]), /Do not pass supervisor --out-dir/u);
+  assert.throws(() => parseArgs(["--scenario", "standard-cycle", "--out-dir=logs/live-supervisor/x"]), /Unknown argument before --: --scenario/u);
+  assert.equal(parseArgs([]).childTimeoutSeconds, DEFAULT_CHILD_TIMEOUT_SECONDS_VALUE);
   assert.match(usage(), /summary/u);
+  assert.match(usage(), /--out-root <dir>/u);
 });
 
 test("supervisor loop summary signatures sort skip reasons", () => {
@@ -62,13 +62,18 @@ test("supervisor loop summary signatures sort skip reasons", () => {
     summarySignature({ ...base, skipReasons: ["b", "a"] }),
     summarySignature({ ...base, skipReasons: ["a", "b"] }),
   );
+  assert.notEqual(
+    summarySignature({ ...base, preflightState: [{ balances: { CKB: { available: "2000" } } }] }),
+    summarySignature({ ...base, preflightState: [{ balances: { CKB: { available: "2001" } } }] }),
+  );
 });
 
 test("supervisor loop summarizes only summary json fields", () => {
   const summary = {
     stopped: "max_cycles",
     aggregateCounts: { bot_no_action_skip: 1, ignored_zero: 0, ignored_string: "1" },
-    txHashesByOutcome: { tester_order_created: ["0xabc"], bad: [1] },
+    txCreatingTxHashCount: 1,
+    txCreatingOutcomeCount: 0,
     artifacts: ["logs/live-supervisor/run/cycle-0001-incident.json"],
     skipReasons: ["fresh-matchable-order", 1],
     publicVsOwnedStateAssumptions: { userOrderCount: 0, marketOrderCount: 1, receiptCount: 2 },
@@ -82,6 +87,7 @@ test("supervisor loop summarizes only summary json fields", () => {
     aggregateCounts: { bot_no_action_skip: 1 },
     outcomes: ["bot_no_action_skip"],
     txCount: 1,
+    hasTxCreatingOutcome: false,
     hasIncident: true,
     skipReasons: ["fresh-matchable-order"],
     publicState: { userOrderCount: 0, marketOrderCount: 1, receiptCount: 2 },
@@ -93,16 +99,38 @@ test("supervisor loop does not treat skip reference hashes as tx-bearing progres
   const run = summarizeRun({
     stopped: "max_cycles",
     aggregateCounts: { tester_fresh_order_skip: 1 },
-    txHashesByOutcome: {
-      tester_fresh_order_skip: ["0x" + "22".repeat(32)],
-    },
+    txCreatingTxHashCount: 0,
+    txCreatingOutcomeCount: 0,
     artifacts: [],
   }, { runIndex: 1, relativeOutDir: "logs/live-supervisor/run", status: 0 });
 
   assert.equal(run.txCount, 0);
+  assert.equal(run.hasTxCreatingOutcome, false);
 });
 
-test("supervisor loop decisions stop on incident, tx, new outcome, and stable no-progress", () => {
+test("supervisor loop stops on tx-creating outcomes even when tx hashes are missing", () => {
+  const run = summarizeRun({
+    stopped: "max_cycles",
+    aggregateCounts: { tester_order_created: 1 },
+    txCreatingTxHashCount: 0,
+    txCreatingOutcomeCount: 1,
+    artifacts: [],
+  }, { runIndex: 1, relativeOutDir: "logs/live-supervisor/run", status: 0 });
+
+  assert.equal(run.txCount, 0);
+  assert.equal(run.hasTxCreatingOutcome, true);
+  assert.equal(decideNext({
+    run,
+    priorOutcomes: new Set(),
+    previousSignature: undefined,
+    stableCount: 0,
+    stableLimit: 3,
+    runIndex: 1,
+    maxRuns: 10,
+  }).reason, "tx_observed");
+});
+
+test("supervisor loop decisions stop on incident, tx, new outcome, max runs, and stable no-progress", () => {
   const priorOutcomes = new Set(["bot_no_action_skip"]);
   const baseRun = {
     status: 0,
@@ -166,29 +194,90 @@ test("supervisor loop decisions stop on incident, tx, new outcome, and stable no
     runIndex: 3,
     maxRuns: 10,
   }).reason, "stable_no_progress");
+  assert.equal(decideNext({
+    run: baseRun,
+    priorOutcomes,
+    previousSignature: "same",
+    stableCount: 2,
+    stableLimit: 3,
+    runIndex: 3,
+    maxRuns: 3,
+  }).reason, "max_runs");
 });
 
 test("supervisor loop runs bounded supervisor commands until stable", async () => {
   const root = "/repo";
+  const originalPrivateKey = process.env.PRIVATE_KEY;
+  process.env.PRIVATE_KEY = "operator-secret";
   const reads = new Map();
   const commands = [];
-  for (let index = 1; index <= 2; index += 1) {
-    reads.set(join(root, "logs/live-supervisor/loop-test", `run-${String(index).padStart(4, "0")}`, "summary.json"), JSON.stringify({
+  try {
+    for (let index = 1; index <= 2; index += 1) {
+      reads.set(join(root, "logs/live-supervisor/loop-test", `run-${String(index).padStart(4, "0")}`, "summary.json"), JSON.stringify({
+          stopped: "max_cycles",
+          aggregateCounts: { bot_no_action_skip: 1 },
+          txCreatingTxHashCount: 0,
+          txCreatingOutcomeCount: 0,
+          artifacts: [],
+          publicVsOwnedStateAssumptions: { marketOrderCount: 0, userOrderCount: 0, receiptCount: 0 },
+      }));
+    }
+    const output = { text: "", write(chunk) { this.text += chunk; } };
+
+    const exitCode = await runSupervisorLoop({
+      argv: [
+        "--out-root", "logs/live-supervisor/loop-test",
+        "--max-runs", "5",
+        "--stable-limit", "2",
+        "--backoff-seconds", "0",
+        "--",
+        "--scenario", "bot-only",
+      ],
+      root,
+      io: { stdout: output, stderr: output },
+      dependencies: {
+        spawnSync: (command, args, options) => {
+          commands.push({ command, args, options });
+          return { status: 0 };
+        },
+        readFile: async (path) => reads.get(path),
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(commands.length, 2);
+    assert.deepEqual(commands[0].args.slice(-4), ["--scenario", "bot-only", "--out-dir", "logs/live-supervisor/loop-test/run-0001"]);
+    assert.equal(commands[0].options.timeout, DEFAULT_CHILD_TIMEOUT_SECONDS_VALUE * 1000);
+    assert.equal(commands[0].options.env.PRIVATE_KEY, undefined);
+    assert.match(output.text, /decision=continue/u);
+    assert.match(output.text, /loop stopped reason=stable_no_progress runs=2/u);
+  } finally {
+    if (originalPrivateKey === undefined) {
+      delete process.env.PRIVATE_KEY;
+    } else {
+      process.env.PRIVATE_KEY = originalPrivateKey;
+    }
+  }
+});
+
+test("supervisor loop accepts validation session out roots", async () => {
+  const root = "/repo";
+  const reads = new Map([
+    [join(root, "log/validation/dynamic-test/chunks/chunk-0001/run-0001/summary.json"), JSON.stringify({
       stopped: "max_cycles",
       aggregateCounts: { bot_no_action_skip: 1 },
-      txHashesByOutcome: {},
+      txCreatingTxHashCount: 0,
+      txCreatingOutcomeCount: 0,
       artifacts: [],
-      publicVsOwnedStateAssumptions: { marketOrderCount: 0, userOrderCount: 0, receiptCount: 0 },
-    }));
-  }
+    })],
+  ]);
+  const commands = [];
   const output = { text: "", write(chunk) { this.text += chunk; } };
 
   const exitCode = await runSupervisorLoop({
     argv: [
-      "--out-root", "logs/live-supervisor/loop-test",
-      "--max-runs", "5",
-      "--stable-limit", "2",
-      "--backoff-seconds", "0",
+      "--out-root", "log/validation/dynamic-test/chunks/chunk-0001",
+      "--max-runs", "1",
       "--",
       "--scenario", "bot-only",
     ],
@@ -204,10 +293,100 @@ test("supervisor loop runs bounded supervisor commands until stable", async () =
   });
 
   assert.equal(exitCode, 0);
-  assert.equal(commands.length, 2);
-  assert.deepEqual(commands[0].args.slice(-4), ["--scenario", "bot-only", "--out-dir", "logs/live-supervisor/loop-test/run-0001"]);
-  assert.match(output.text, /decision=continue/u);
-  assert.match(output.text, /loop stopped reason=stable_no_progress runs=2/u);
+  assert.deepEqual(commands[0].args.slice(-4), ["--scenario", "bot-only", "--out-dir", "log/validation/dynamic-test/chunks/chunk-0001/run-0001"]);
+  assert.match(output.text, /out=log\/validation\/dynamic-test\/chunks\/chunk-0001/u);
+});
+
+test("supervisor loop rejects validation out roots outside chunk directories", async () => {
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runSupervisorLoop({
+    argv: ["--out-root", "log/validation/dynamic-test"],
+    root: "/repo",
+    io: { stdout: output, stderr: output },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(output.text, /validation session chunks directory/u);
+});
+
+test("supervisor loop rejects validation chunk root descendants", async () => {
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runSupervisorLoop({
+    argv: ["--out-root", "log/validation/dynamic-test/chunks/chunk-0001/extra"],
+    root: "/repo",
+    io: { stdout: output, stderr: output },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(output.text, /validation session chunks directory/u);
+});
+
+test("supervisor loop accepts explicit validation roots outside the repo", async () => {
+  const root = "/repo";
+  const reads = new Map([
+    ["/var/tmp/ickb-log/validation/dynamic-test/chunks/chunk-0001/run-0001/summary.json", JSON.stringify({
+      stopped: "max_cycles",
+      aggregateCounts: { bot_no_action_skip: 1 },
+      txCreatingTxHashCount: 0,
+      txCreatingOutcomeCount: 0,
+      artifacts: [],
+    })],
+  ]);
+  const commands = [];
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+
+  const exitCode = await runSupervisorLoop({
+    argv: [
+      "--out-root", "/var/tmp/ickb-log/validation/dynamic-test/chunks/chunk-0001",
+      "--max-runs", "1",
+      "--",
+      "--scenario", "bot-only",
+    ],
+    root,
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      spawnSync: (command, args, options) => {
+        commands.push({ command, args, options });
+        return { status: 0 };
+      },
+      readFile: async (path) => reads.get(path),
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.deepEqual(commands[0].args.slice(-4), ["--scenario", "bot-only", "--out-dir", "/var/tmp/ickb-log/validation/dynamic-test/chunks/chunk-0001/run-0001"]);
+  assert.match(output.text, /out=\/var\/tmp\/ickb-log\/validation\/dynamic-test\/chunks\/chunk-0001/u);
+});
+
+test("supervisor loop applies child timeout at the outer process boundary", async () => {
+  const root = "/repo";
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const commands = [];
+  const exitCode = await runSupervisorLoop({
+    argv: [
+      "--out-root", "logs/live-supervisor/loop-timeout",
+      "--child-timeout-seconds", "1",
+      "--backoff-seconds", "0",
+    ],
+    root,
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      spawnSync: (command, args, options) => {
+        commands.push({ command, args, options });
+        return { status: null, signal: "SIGTERM", error: Object.assign(new Error("spawnSync timed out"), { code: "ETIMEDOUT" }) };
+      },
+      readFile: async () => {
+        const error = new Error("missing");
+        error.code = "ENOENT";
+        throw error;
+      },
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(commands[0].options.timeout, 1000);
+  assert.equal(commands[0].options.killSignal, "SIGTERM");
+  assert.match(output.text, /summary=missing_or_invalid/u);
 });
 
 test("supervisor loop stops for inspection on new tx-bearing summary", async () => {
@@ -222,6 +401,8 @@ test("supervisor loop stops for inspection on new tx-bearing summary", async () 
       readFile: async () => JSON.stringify({
         stopped: "stop_after_tx_count",
         aggregateCounts: { tester_order_created: 1 },
+        txCreatingTxHashCount: 1,
+        txCreatingOutcomeCount: 1,
         txHashesByOutcome: { tester_order_created: ["0x" + "11".repeat(32)] },
         artifacts: [],
       }),
@@ -231,6 +412,33 @@ test("supervisor loop stops for inspection on new tx-bearing summary", async () 
   assert.equal(exitCode, 0);
   assert.match(output.text, /decision=tx_observed/u);
   assert.match(output.text, /tx=1/u);
+});
+
+test("supervisor loop requires summary-owned tx counters", () => {
+  assert.throws(() => summarizeRun({
+    stopped: "max_cycles",
+    aggregateCounts: { tester_order_created: 1 },
+    txHashesByOutcome: { tester_order_created: ["0x" + "11".repeat(32)] },
+    artifacts: [],
+  }, { runIndex: 1, relativeOutDir: "logs/live-supervisor/run", status: 0 }), /txCreatingTxHashCount/u);
+});
+
+test("supervisor loop refuses symlinked output roots", async () => {
+  const output = { text: "", write(chunk) { this.text += chunk; } };
+  const exitCode = await runSupervisorLoop({
+    argv: ["--out-root", "logs/live-supervisor/loop-symlink"],
+    root: "/repo",
+    io: { stdout: output, stderr: output },
+    dependencies: {
+      lstat: async (path) => ({ isSymbolicLink: () => path === join("/repo", "logs", "live-supervisor") }),
+      spawnSync: () => {
+        throw new Error("should not spawn supervisor through symlinked output root");
+      },
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(output.text, /Refusing to use loop output root through symlinked path: logs\/live-supervisor/u);
 });
 
 test("supervisor loop reports invalid out-root as a concise CLI error", async () => {
@@ -243,7 +451,7 @@ test("supervisor loop reports invalid out-root as a concise CLI error", async ()
   });
 
   assert.equal(exitCode, 1);
-  assert.match(output.text, /--out-root must be under logs\/live-supervisor/u);
+  assert.match(output.text, /--out-root must be under logs\/live-supervisor or a validation session chunks directory/u);
   assert.doesNotMatch(output.text, /\n\s+at\s/u);
 });
 


### PR DESCRIPTION
## Why

Live testnet supervision needs bounded evidence artifacts that external loops can inspect without re-entering funded actor state or inheriting operator secrets.

## Changes

- Expand the supervisor summary with tx-creating counters, tester order evidence, preflight state, scenario attempts, and validation-session output path support.
- Tighten supervisor-loop decisions around summary-owned tx counters, validation chunk roots, child timeouts, symlink checks, and minimal child environments.
- Add a dynamic supervisor loop that chooses fundable tester stimuli from preflight balances and delegates bounded chunks to the supervisor loop.
- Document live supervisor, loop, and dynamic-loop usage.