### PR TITLE
Clarify live config and log boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ pnpm --filter @ickb/supervisor build
 pnpm live:supervisor
 ```
 
-By default the supervisor uses ignored `config/bot-testnet.json` and `config/tester-testnet.json`, writes standalone artifacts under ignored `logs/live-supervisor/<run-id>/` paths, and runs deterministic bounded bot/tester commands only. It does not patch, verify, rebuild, relaunch, or invoke an LLM; external loops and operators consume `summary.json` between runs.
+By default the supervisor uses ignored `config/bot-testnet.json` and `config/tester-testnet.json`, writes standalone artifacts under ignored `logs/live-supervisor/<run-id>/` paths, and runs deterministic bounded bot/tester commands only.
 
-`pnpm live:preflight -- --config config/bot-testnet.json --role bot` prints public balance evidence for funding checks. Check `balances.CKB.available` together with `balances.CKB.reserve`, `balances.CKB.spendable`, and `capital.minimumCkbCapital`; raw available CKB is not the same as bot-spendable CKB.
+Rebuild disposable live configs from `ICKB_TESTNET_BOT_PRIVATE_KEY` and `ICKB_TESTNET_TESTER_PRIVATE_KEY` with `pnpm live:config-from-env -- --force` when they are missing or stale; `ICKB_TESTNET_RPC_URL` is optional. The supervisor does not patch, verify, rebuild, relaunch, or invoke an LLM; external loops and operators consume `summary.json` between runs.
+
+`pnpm live:preflight -- --config config/bot-testnet.json --role bot` prints public balance evidence for funding checks. Use `key.recommendedAddress` as the funding address, then rerun preflight and check `balances.CKB.total`, `balances.CKB.available`, `balances.CKB.reserve`, `balances.CKB.spendable`, and `capital.minimumCkbCapital`; raw available CKB is not the same as bot-spendable CKB. For machine-readable JSON without package-manager output, run `node scripts/ickb-live-preflight.mjs --config config/bot-testnet.json --role bot` directly.
 
 For repeated bounded invocations, keep loop-owned options before `--` and supervisor options after it:
 
@@ -129,7 +131,7 @@ Dynamic validation sessions default to ignored `log/validation/dynamic-<time>-<p
 pnpm live:supervisor:dynamic-loop --log-root log --max-chunks 2 -- --target-outcome bot_match_committed
 ```
 
-Session layout is source-separated: `operator/events.ndjson`, `operator/launch.json`, optional `operator/stderr.log`, and `chunks/chunk-0001/run-0001/summary.json` plus the supervisor-owned preflight, bot, tester, and supervisor artifacts.
+Session layout is source-separated: `operator/events.ndjson`, `operator/launch.json`, optional `operator/stderr.log`, and `chunks/chunk-0001/run-0001/summary.json` plus the supervisor-owned preflight, bot, tester, and supervisor artifacts. Production bot-only logs remain separate under the configured production log root, for example `<log-root>/bot/testnet/bot.events.ndjson`.
 
 Explicit repeatable `--target-outcome` requests become bounded coverage contracts: if `--max-cycles` ends before they are observed, the supervisor writes a logical incident for external review. The supervisor treats public testnet iCKB deposits, receipts, and orders as observable stress surface, but only bot/tester-owned state from the supplied configs is treated as spend authority.
 

--- a/apps/supervisor/README.md
+++ b/apps/supervisor/README.md
@@ -106,4 +106,4 @@ The dynamic loop writes operator records under the session and passes each chunk
   chunks/chunk-0001/run-0001/cycle-0001-tester.stdout.ndjson
 ```
 
-Production bot-only logs can share the same configured log root but stay under `bot/<network>/`, for example `<log-root>/bot/testnet/bot.events.ndjson`. See `apps/bot/README.md` for the production launcher layout.
+Production bot-only logs can share the same configured log root but stay under `bot/<network>/`, for example `<log-root>/bot/testnet/bot.events.ndjson`. See [apps/bot/README.md](../bot/README.md) for the production launcher layout.

--- a/apps/supervisor/README.md
+++ b/apps/supervisor/README.md
@@ -20,7 +20,17 @@ Run from the repo root:
 pnpm live:supervisor
 ```
 
-By default this uses `config/bot-testnet.json` and `config/tester-testnet.json`. Configs must be ignored JSON files with `maxIterations: 1`; the supervisor refuses to launch an actor when preflight reports the config is missing that one-iteration bound. The supervisor passes config paths to the existing app env names and does not print config contents.
+By default this uses `config/bot-testnet.json` and `config/tester-testnet.json`. Configs must be ignored JSON files with `maxIterations: 1`; the supervisor refuses to launch an actor when preflight reports the config is missing that one-iteration bound.
+
+Treat these files as disposable local output: rebuild them from `ICKB_TESTNET_BOT_PRIVATE_KEY` and `ICKB_TESTNET_TESTER_PRIVATE_KEY` with `pnpm live:config-from-env -- --force` when they are missing or stale. `ICKB_TESTNET_RPC_URL` is optional; when omitted, the generated JSON omits `rpcUrl` and CCC chooses its default testnet endpoint. The supervisor passes config paths to the existing app env names and does not print config contents.
+
+To get a public funding address and verify balances without printing config contents, run:
+
+```bash
+pnpm live:preflight -- --config config/bot-testnet.json --role bot
+```
+
+Use `key.recommendedAddress` as the funding address. After funding, rerun the same preflight command and check `balances.CKB.total`, `balances.CKB.available`, `balances.CKB.reserve`, `balances.CKB.spendable`, and `capital.minimumCkbCapital`. If you need machine-readable JSON for piping, run `node scripts/ickb-live-preflight.mjs --config config/bot-testnet.json --role bot` directly so package-manager output is not mixed into stdout.
 
 ## Artifacts
 
@@ -77,7 +87,7 @@ The external loop also has a loop-owned `--child-timeout-seconds` guard for the 
 
 For continuous tester-bot matching, use `node scripts/ickb-supervisor-dynamic-loop.mjs` or `pnpm live:supervisor:dynamic-loop`. This remains outside `apps/supervisor`: it reads tester preflight balance summaries, chooses a currently fundable tester scenario, and delegates each bounded chunk to `scripts/ickb-supervisor-loop.mjs`. When `--target-outcome tester_fresh_order_skip` is passed through, supervisor auto-planning can choose `tester-fresh-skip-two-pass`; the dynamic loop itself only chooses fundable tester stimuli.
 
-Dynamic loop sessions are live-validation artifacts. They default to ignored `log/validation/dynamic-<time>-<pid>/`; override the root with `--log-root <path>` or pin one run with `--session-root <path>`. The session root must be exactly `<log-root>/validation/<session>`, stay under the resolved log root, avoid symlinked parents, and not already exist. The dynamic loop derives its chunk timeout from the delegated supervisor-loop child timeout, chunk run count, and chunk backoff unless `--chunk-timeout-seconds` is explicitly set high enough, so an outer chunk timeout does not kill the supervisor-loop process before it can enforce its child cleanup boundary.
+Dynamic loop sessions are live-validation artifacts, separate from production bot-only logs. They default to ignored `log/validation/dynamic-<time>-<pid>/`; override the root with `--log-root <path>` or pin one run with `--session-root <path>`. The session root must be exactly `<log-root>/validation/<session>`, stay under the resolved log root, avoid symlinked parents, and not already exist. The dynamic loop derives its chunk timeout from the delegated supervisor-loop child timeout, chunk run count, and chunk backoff unless `--chunk-timeout-seconds` is explicitly set high enough, so an outer chunk timeout does not kill the supervisor-loop process before it can enforce its child cleanup boundary.
 
 ```bash
 node scripts/ickb-supervisor-dynamic-loop.mjs --log-root log --max-chunks 2 -- --target-outcome bot_match_committed
@@ -95,3 +105,5 @@ The dynamic loop writes operator records under the session and passes each chunk
   chunks/chunk-0001/run-0001/cycle-0001-bot.stdout.ndjson
   chunks/chunk-0001/run-0001/cycle-0001-tester.stdout.ndjson
 ```
+
+Production bot-only logs can share the same configured log root but stay under `bot/<network>/`, for example `<log-root>/bot/testnet/bot.events.ndjson`. See `apps/bot/README.md` for the production launcher layout.

--- a/apps/tester/README.md
+++ b/apps/tester/README.md
@@ -12,6 +12,18 @@ The tester reads one strict JSON config file named by `TESTER_CONFIG_FILE`:
 
 The JSON config accepts exactly `chain`, `privateKey`, optional `rpcUrl`, `sleepIntervalSeconds`, optional `maxIterations`, and optional `maxRetryableAttempts`. Unknown keys, wrong types, non-HTTP(S) RPC URLs, whitespace/control characters in `rpcUrl`, and non-canonical private keys are rejected. Omitting `rpcUrl` lets CCC use its default endpoint. The private key must be exactly lowercase `0x` plus 64 lowercase hex characters, with no newline, spaces, tabs, or comments. Local config files under `config/` are ignored by git.
 
+Shared live config helpers may include `maxRetryableAttempts` in tester configs, but the tester loop currently uses `maxIterations`; the retryable-attempt budget is bot-owned.
+
+For local testnet live supervision, the shared root helper generates both bot and tester configs, so keep funded identities in external environment variables and rebuild disposable ignored configs when needed:
+
+```bash
+export ICKB_TESTNET_BOT_PRIVATE_KEY='0x...'
+export ICKB_TESTNET_TESTER_PRIVATE_KEY='0x...'
+# Optional: export ICKB_TESTNET_RPC_URL='https://...'
+# Optional: export ICKB_TESTNET_MAX_RETRYABLE_ATTEMPTS=10
+pnpm live:config-from-env -- --force
+```
+
 Current network support:
 
 - `"chain":"testnet"`


### PR DESCRIPTION
## Why
Live testnet operators need the config-generation, preflight funding, and log-boundary details in the public docs without relying on scratch notes or stale WIP.

## Changes
- Document rebuilding ignored live configs from environment variables and the optional testnet RPC URL.
- Clarify preflight funding checks, balance fields, and direct machine-readable JSON usage.
- Distinguish dynamic validation sessions from production bot-only logs and note the tester retry-budget boundary.