### PR TITLE
Report projected CKB in live preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ By default the supervisor uses ignored `config/bot-testnet.json` and `config/tes
 
 Rebuild disposable live configs from `ICKB_TESTNET_BOT_PRIVATE_KEY` and `ICKB_TESTNET_TESTER_PRIVATE_KEY` with `pnpm live:config-from-env -- --force` when they are missing or stale; `ICKB_TESTNET_RPC_URL` is optional. The supervisor does not patch, verify, rebuild, relaunch, or invoke an LLM; external loops and operators consume `summary.json` between runs.
 
-`pnpm live:preflight -- --config config/bot-testnet.json --role bot` prints public balance evidence for funding checks. Use `key.recommendedAddress` as the funding address, then rerun preflight and check `balances.CKB.total`, `balances.CKB.available`, `balances.CKB.reserve`, `balances.CKB.spendable`, and `capital.minimumCkbCapital`; raw available CKB is not the same as bot-spendable CKB. For machine-readable JSON without package-manager output, run `node scripts/ickb-live-preflight.mjs --config config/bot-testnet.json --role bot` directly.
+`pnpm live:preflight -- --config config/bot-testnet.json --role bot` prints public balance evidence for funding checks. Use `key.recommendedAddress` as the funding address, then rerun preflight and check `balances.CKB.available`, `balances.CKB.reserve`, `balances.CKB.spendable`, `balances.CKB.projectedAvailable`, `balances.CKB.total`, and `capital.minimumCkbCapital`; `available` and `spendable` are actual plain-cell values, while `projectedAvailable` and `total` are projected accounting values. For machine-readable JSON without package-manager output, run `node scripts/ickb-live-preflight.mjs --config config/bot-testnet.json --role bot` directly.
 
 For repeated bounded invocations, keep loop-owned options before `--` and supervisor options after it:
 

--- a/apps/supervisor/README.md
+++ b/apps/supervisor/README.md
@@ -30,7 +30,7 @@ To get a public funding address and verify balances without printing config cont
 pnpm live:preflight -- --config config/bot-testnet.json --role bot
 ```
 
-Use `key.recommendedAddress` as the funding address. After funding, rerun the same preflight command and check `balances.CKB.total`, `balances.CKB.available`, `balances.CKB.reserve`, `balances.CKB.spendable`, and `capital.minimumCkbCapital`. If you need machine-readable JSON for piping, run `node scripts/ickb-live-preflight.mjs --config config/bot-testnet.json --role bot` directly so package-manager output is not mixed into stdout.
+Use `key.recommendedAddress` as the funding address. After funding, rerun the same preflight command and check `balances.CKB.available`, `balances.CKB.reserve`, `balances.CKB.spendable`, `balances.CKB.projectedAvailable`, `balances.CKB.total`, and `capital.minimumCkbCapital`. `available` and `spendable` are actual plain-cell values, while `projectedAvailable` and `total` can include projected sources such as ready withdrawals. If you need machine-readable JSON for piping, run `node scripts/ickb-live-preflight.mjs --config config/bot-testnet.json --role bot` directly so package-manager output is not mixed into stdout.
 
 ## Artifacts
 

--- a/scripts/ickb-live-preflight.mjs
+++ b/scripts/ickb-live-preflight.mjs
@@ -172,6 +172,7 @@ export async function buildPreflightReport({
     balances: {
       CKB: {
         available: nodeUtils.formatCkb(plainCkb),
+        projectedAvailable: nodeUtils.formatCkb(projection.ckbAvailable),
         reserve: nodeUtils.formatCkb(ckbReserve),
         spendable: nodeUtils.formatCkb(spendableCkb),
         unavailable: nodeUtils.formatCkb(projection.ckbPending),

--- a/scripts/ickb-live-preflight.test.mjs
+++ b/scripts/ickb-live-preflight.test.mjs
@@ -144,6 +144,7 @@ test("preflight reports CKB reserve and spendable balance separately", async () 
 
     assert.deepEqual(report.balances.CKB, {
       available: "150000000000",
+      projectedAvailable: "190000000000",
       reserve: "100000000000",
       spendable: "50000000000",
       unavailable: "25000000000",
@@ -186,6 +187,7 @@ test("preflight reports tester reserve and spendable balance separately", async 
 
     assert.deepEqual(report.balances.CKB, {
       available: "250000000000",
+      projectedAvailable: "280000000000",
       reserve: "200000000000",
       spendable: "50000000000",
       unavailable: "25000000000",


### PR DESCRIPTION
## Why
Live preflight already reports actual owned plain CKB for reserve checks and projected total CKB for capital checks. Operators also need to see the projected available CKB value directly without mistaking it for spendable reserve capacity.

## Changes
- Add `balances.CKB.projectedAvailable` to live preflight output.
- Keep `balances.CKB.available` and `balances.CKB.spendable` based on actual owned plain CKB cells.
- Update focused preflight tests and docs to distinguish actual plain-cell values from projected accounting values.