### PR TITLE
fix(supervisor): stop on unclassified bot transactions

### DIFF
--- a/apps/supervisor/src/index.test.ts
+++ b/apps/supervisor/src/index.test.ts
@@ -1381,6 +1381,23 @@ describe("classification", () => {
     });
   });
 
+  it("treats committed bot transactions without classifiable actions as terminal", () => {
+    const stdout = [
+      botEvent("bot.transaction.built", {
+        actions: { collectedOrders: 0, completedDeposits: 0, matchedOrders: 0, deposits: 0, withdrawalRequests: 0, withdrawals: 0 },
+      }),
+      botEvent("bot.transaction.committed", { txHash: txHash("47"), status: "committed" }),
+    ].map(JSON.stringify).join("\n");
+
+    expect(classifyActorResult("bot", commandResult("bot", stdout))).toMatchObject({
+      outcome: "unknown",
+      terminal: true,
+      reason: "bot committed transaction evidence did not include classifiable action evidence",
+      actions: { matchedOrders: 0, deposits: 0, withdrawalRequests: 0, completedDeposits: 0, withdrawals: 0 },
+      txHashes: [txHash("47")],
+    });
+  });
+
   it("keeps match diagnostics tied to the matching state-read iteration", () => {
     const stdout = [
       botEvent("bot.state.read", {

--- a/apps/supervisor/src/index.ts
+++ b/apps/supervisor/src/index.ts
@@ -1371,9 +1371,20 @@ function classifyBotResult(
     if (actions === undefined) {
       return { ...base, outcome: "malformed_evidence", terminal: true, reason: "bot committed transaction evidence did not include matching built action evidence", publicState };
     }
+    const outcome = classifyBotCommittedActions(actions);
+    if (outcome === "unknown") {
+      return {
+        ...base,
+        outcome,
+        terminal: true,
+        reason: "bot committed transaction evidence did not include classifiable action evidence",
+        actions,
+        publicState,
+      };
+    }
     return {
       ...base,
-      outcome: classifyBotCommittedActions(actions),
+      outcome,
       terminal: false,
       reason: "bot transaction committed according to app evidence",
       actions,


### PR DESCRIPTION
## Why

Committed bot transactions with action evidence that cannot map to a supervisor outcome should stop the live loop as an incident instead of continuing as a non-terminal unknown result.

## Changes

- Classify committed bot transactions with unclassifiable action counts as terminal unknown.
- Preserve the committed tx hash and action evidence in the supervisor result.
- Add regression coverage for the terminal unknown classification.